### PR TITLE
Enhancement: Enable unused_use fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -78,6 +78,7 @@ class Refinery29 extends Config
             'ternary_spaces',
             'trim_array_spaces',
             'unalign_double_arrow',
+            'unused_use',
             'whitespacy_lines',
         ];
     }

--- a/tests/Refinery29Test.php
+++ b/tests/Refinery29Test.php
@@ -167,6 +167,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'ternary_spaces',
             'trim_array_spaces',
             'unalign_double_arrow',
+            'unused_use',
             'whitespacy_lines',
         ];
     }


### PR DESCRIPTION
This PR

* [x] enables the `unused_use` fixer

See https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

> **unused_use [symfony]**
> Unused use statements must be removed.