### PR TITLE
Enhancement: Enable method_separation fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -47,6 +47,7 @@ class Refinery29 extends Config
             'include',
             'join_function',
             'list_commas',
+            'method_separation',
             'multiline_array_trailing_comma',
             'namespace_no_leading_whitespace',
             'new_with_braces',

--- a/tests/Refinery29Test.php
+++ b/tests/Refinery29Test.php
@@ -136,6 +136,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'include',
             'join_function',
             'list_commas',
+            'method_separation',
             'multiline_array_trailing_comma',
             'namespace_no_leading_whitespace',
             'new_with_braces',


### PR DESCRIPTION
This PR

* [x] enables the `method_separation` fixer

See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

> **method_separation [symfony]**
> Methods must be separated with one blank line.