### PR TITLE
Enhancement: Only require PHP5.4 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 
 matrix:
   include:
+    - php: 5.4
     - php: 5.5
     - php: 5.6
       env: COLLECT_COVERAGE=true CHECK_CS=true

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=5.4",
         "fabpot/php-cs-fixer": "2.0.*@dev"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a4bfbf11b97e2047bdf44dd94aba359b",
+    "hash": "b1bcbbbd3edc0c281a82f4737dcc6c9d",
     "packages": [
         {
             "name": "fabpot/php-cs-fixer",
@@ -16,7 +16,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/4bc3df84dddf2629e6d96d6216f9ccae61d99389",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/ead0d6d8f714cf1b60df49800b28a76a96bd9466",
                 "reference": "4bc3df84dddf2629e6d96d6216f9ccae61d99389",
                 "shasum": ""
             },
@@ -122,12 +122,12 @@
             "version": "v2.7.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Console.git",
+                "url": "git@github.com:symfony/Console.git",
                 "reference": "d6cf02fe73634c96677e428f840704bfbcaec29e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/d6cf02fe73634c96677e428f840704bfbcaec29e",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/c0bc26eabd880b1e9362471a0e2a30b492d043a9",
                 "reference": "d6cf02fe73634c96677e428f840704bfbcaec29e",
                 "shasum": ""
             },
@@ -1646,7 +1646,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5"
+        "php": ">=5.4"
     },
     "platform-dev": []
 }

--- a/tests/Refinery29Test.php
+++ b/tests/Refinery29Test.php
@@ -79,7 +79,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \Generator
+     * @return array
      */
     public function providerDoesNotHaveFixerEnabled()
     {
@@ -101,12 +101,16 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'self_accessor' => 'it causes an edge case error',
         ];
 
+        $data = [];
+
         foreach ($fixers as $fixer => $reason) {
-            yield [
+            $data[] = [
                 $fixer,
                 $reason,
             ];
         }
+
+        return $data;
     }
 
     /**

--- a/tests/Refinery29Test.php
+++ b/tests/Refinery29Test.php
@@ -3,7 +3,6 @@
 namespace Refinery29\CS\Config\Test;
 
 use Refinery29\CS\Config\Refinery29;
-use Symfony\CS\ConfigInterface;
 use Symfony\CS\FixerInterface;
 
 class Refinery29Test extends \PHPUnit_Framework_TestCase
@@ -12,7 +11,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
     {
         $config = new Refinery29();
 
-        $this->assertInstanceOf(ConfigInterface::class, $config);
+        $this->assertInstanceOf('Symfony\CS\ConfigInterface', $config);
     }
 
     public function testValues()


### PR DESCRIPTION
This PR

* [x] runs a build against PHP5.4
* [x] requires PHP5.4 and above in `composer.json`
* [x] removes usages of the `class` keyword