### PR TITLE
Enhancement: Enable phpdoc_types fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -79,7 +79,7 @@ class Refinery29 extends Config
             'phpdoc_short_description' => false,
             'phpdoc_to_comment' => true,
             'phpdoc_trim' => true,
-            'phpdoc_types' => false, // new
+            'phpdoc_types' => true,
             'phpdoc_type_to_var' => true,
             'phpdoc_var_without_name' => true,
             'pre_increment' => false,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -180,7 +180,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'phpdoc_short_description' => false,
             'phpdoc_to_comment' => true,
             'phpdoc_trim' => true,
-            'phpdoc_types' => false,
+            'phpdoc_types' => true,
             'phpdoc_type_to_var' => true,
             'phpdoc_var_without_name' => true,
             'pre_increment' => false,


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_types` fixer

See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

> `phpdoc_types`
The correct case must be used for standard PHP types in phpdoc.