### PR TITLE
Fix: Drop PHP5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
 
 matrix:
   include:
-    - php: 5.4
     - php: 5.5
     - php: 5.6
       env: COLLECT_COVERAGE=true CHECK_CS=true

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.5",
         "fabpot/php-cs-fixer": "dev-master#59ed377 as 2.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a4839d73e173d816efd0ea092b2ab899",
-    "content-hash": "1cd4d75071ba73f46ce74bf6fab07a57",
+    "hash": "a921b9d18eebaf48be820573140daecc",
+    "content-hash": "512fc62e550138704ce403b24251b883",
     "packages": [
         {
             "name": "fabpot/php-cs-fixer",
@@ -17,7 +17,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/b55f70c796091901697b069e69a4a89f8a7be837",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/7b129979046ceaa47e985db3ae509f811989f83a",
                 "reference": "59ed377",
                 "shasum": ""
             },
@@ -1655,7 +1655,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4"
+        "php": ">=5.5"
     },
     "platform-dev": []
 }

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -3,6 +3,7 @@
 namespace Refinery29\CS\Config\Test;
 
 use Refinery29\CS\Config\Refinery29;
+use Symfony\CS\ConfigInterface;
 
 class Refinery29Test extends \PHPUnit_Framework_TestCase
 {
@@ -10,7 +11,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
     {
         $config = new Refinery29();
 
-        $this->assertInstanceOf('Symfony\CS\ConfigInterface', $config);
+        $this->assertInstanceOf(ConfigInterface::class, $config);
     }
 
     public function testValues()


### PR DESCRIPTION
This PR

* [x] requires at least PHP5.5
* [x] removes PHP5.4 from the build matrix
* [x] uses the `class` keyword