### PR TITLE
Enhancement: Enable array_element_no_space_before_comma fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -52,6 +52,7 @@ class Refinery29 extends Config
     {
         return [
             'alias_functions' => true,
+            'array_element_no_space_before_comma' => true,
             'blankline_after_open_tag' => true,
             'concat_without_spaces' => false,
             'double_arrow_multiline_whitespaces' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -154,6 +154,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
     {
         return [
             'alias_functions' => true,
+            'array_element_no_space_before_comma' => true,
             'blankline_after_open_tag' => true,
             'concat_without_spaces' => false,
             'double_arrow_multiline_whitespaces' => true,


### PR DESCRIPTION
This PR

* [x] enables the `array_element_no_space_before_comma` fixer

See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

> `array_element_no_space_before_comma [@Symfony]`
In array declaration, there MUST NOT be a whitespace before each comma.