### PR TITLE
Enhancement: Enable array_element_white_space_after_comma fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -53,6 +53,7 @@ class Refinery29 extends Config
         return [
             'alias_functions' => true,
             'array_element_no_space_before_comma' => true,
+            'array_element_white_space_after_comma' => true,
             'blankline_after_open_tag' => true,
             'concat_without_spaces' => false,
             'double_arrow_multiline_whitespaces' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -155,6 +155,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
         return [
             'alias_functions' => true,
             'array_element_no_space_before_comma' => true,
+            'array_element_white_space_after_comma' => true,
             'blankline_after_open_tag' => true,
             'concat_without_spaces' => false,
             'double_arrow_multiline_whitespaces' => true,


### PR DESCRIPTION
This PR

* [x] enables the `array_element_white_space_after_comma` fixer

See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

> `array_element_white_space_after_comma [@Symfony]`
In array declaration, there MUST be a whitespace after each comma.
