### PR TITLE
Enhancement: Enable unneeded_control_parentheses fixer

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "7b129979046ceaa47e985db3ae509f811989f83a"
+                "reference": "99c5aca8aa44fd103f617f51b716f83802886fb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/7b129979046ceaa47e985db3ae509f811989f83a",
-                "reference": "7b129979046ceaa47e985db3ae509f811989f83a",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/99c5aca8aa44fd103f617f51b716f83802886fb6",
+                "reference": "99c5aca8aa44fd103f617f51b716f83802886fb6",
                 "shasum": ""
             },
             "require": {
@@ -64,7 +64,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2015-12-01 22:49:21"
+            "time": "2015-12-20 13:21:38"
         },
         {
             "name": "sebastian/diff",

--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -99,6 +99,7 @@ class Refinery29 extends Config
             'trim_array_spaces' => true,
             'unalign_double_arrow' => true,
             'unalign_equals' => true,
+            'unneeded_control_parentheses' => true,
             'unused_use' => true,
             'whitespacy_lines' => true,
         ];

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -201,6 +201,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'trim_array_spaces' => true,
             'unalign_double_arrow' => true,
             'unalign_equals' => true,
+            'unneeded_control_parentheses' => true,
             'unused_use' => true,
             'whitespacy_lines' => true,
         ];


### PR DESCRIPTION
This PR

* [x] updates `fabpot/php-cs-fixer`
* [x] enables the `unneeded_control_parentheses` fixer

:information_desk_person: See https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

> **unneeded_control_parentheses [symfony]**
Removes unneeded parentheses around control statements.

