### PR TITLE
Enhancement: Enable spaces_after_semicolon fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -92,6 +92,7 @@ class Refinery29 extends Config
             'single_array_no_trailing_comma' => true,
             'single_blank_line_before_namespace' => true,
             'single_quote' => true,
+            'spaces_after_semicolon' => true,
             'spaces_before_semicolon' => true,
             'spaces_cast' => true,
             'standardize_not_equal' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -194,6 +194,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'single_array_no_trailing_comma' => true,
             'single_blank_line_before_namespace' => true,
             'single_quote' => true,
+            'spaces_after_semicolon' => true,
             'spaces_before_semicolon' => true,
             'spaces_cast' => true,
             'standardize_not_equal' => true,


### PR DESCRIPTION
This PR

* [x] enables the `spaces_after_semicolon` fixer

:information_desk_person: See https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

> **spaces_after_semicolon** [symfony]
Fix whitespace after a semicolon.