### PR TITLE
Enhancement: Enable short_bool_cast fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -89,6 +89,7 @@ class Refinery29 extends Config
             'remove_lines_between_uses' => true,
             'return' => true,
             'self_accessor' => false,
+            'short_bool_cast' => true,
             'single_array_no_trailing_comma' => true,
             'single_blank_line_before_namespace' => true,
             'single_quote' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -191,6 +191,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'remove_lines_between_uses' => true,
             'return' => true,
             'self_accessor' => false,
+            'short_bool_cast' => true,
             'single_array_no_trailing_comma' => true,
             'single_blank_line_before_namespace' => true,
             'single_quote' => true,


### PR DESCRIPTION
This PR

* [x] enables the `short_bool_cast` fixer

:information_desk_person: See https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

> **short_bool_cast** [symfony]
Short cast bool using double exclamation mark should not be used.