### PR TITLE
Enhancement: Allow to specify a header comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ $config->setCacheFile($cacheDir . '/.php_cs.cache');
 return $config;
 ```
 
+:bulb: Optionally, you can specify a header comment to use, which will automatically enable the `header_comment` fixer:
+
+```php
+$header = <<<EOF
+Copyright (c) 2016 Refinery29, Inc.
+
+For the full copyright and license information, please view
+the LICENSE file that was distributed with this source code.
+EOF;
+
+$config = new Refinery29\CS\Config\Refinery29($header);
+```
+
 ### Git
 
 Add `.php_cs.cache` (this is the cache file created by `php-cs-fixer`) to `.gitignore`:

--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -6,9 +6,19 @@ use Symfony\CS\Config\Config;
 
 class Refinery29 extends Config
 {
-    public function __construct($name = 'refinery29', $description = 'The configuration for Refinery29 PHP applications')
+    /**
+     * @var string
+     */
+    private $header;
+
+    /**
+     * @param string $header
+     */
+    public function __construct($header = null)
     {
-        parent::__construct($name, $description);
+        parent::__construct('refinery29', 'The configuration for Refinery29 PHP applications');
+
+        $this->header = $header;
     }
 
     public function usingCache()
@@ -112,7 +122,7 @@ class Refinery29 extends Config
      */
     protected function getContribRules()
     {
-        return [
+        $rules = [
             'align_double_arrow' => false,
             'align_equals' => false,
             'concat_with_spaces' => true,
@@ -137,5 +147,13 @@ class Refinery29 extends Config
             'strict' => false,
             'strict_param' => false,
         ];
+
+        if ($this->header !== null) {
+            $rules['header_comment'] = [
+                'header' => $this->header,
+            ];
+        }
+
+        return $rules;
     }
 }

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -58,6 +58,33 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testDoesNotHaveHeaderCommentFixerByDefault()
+    {
+        $config = new Refinery29();
+
+        $rules = $config->getRules();
+
+        $this->assertArrayHasKey('header_comment', $rules);
+        $this->assertFalse($rules['header_comment']);
+    }
+
+    public function testHasHeaderCommentFixerIfProvided()
+    {
+        $header = 'foo';
+
+        $config = new Refinery29($header);
+
+        $rules = $config->getRules();
+
+        $this->assertArrayHasKey('header_comment', $rules);
+
+        $expected = [
+            'header' => $header,
+        ];
+
+        $this->assertSame($expected, $rules['header_comment']);
+    }
+
     /**
      * @param array  $expected
      * @param array  $actual
@@ -111,7 +138,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'align_double_arrow' => 'it conflicts with unalign_double_arrow (which is enabled)',
             'align_equals' => 'it conflicts with unalign_double (yet to be enabled)',
             'concat_without_spaces' => 'it conflicts with concat_with_spaces (which is enabled)',
-            'header_comment' => 'we do not have a header we want to add/replace (yet)',
+            'header_comment' => 'it is not enabled by default',
             'ereg_to_preg' => 'it changes behaviour',
             'logical_not_operators_with_spaces' => 'we do not need leading and trailing whitespace before !',
             'logical_not_operators_with_successor_space' => 'we have not decided to use this one (yet)',


### PR DESCRIPTION
This PR

* [x] allows to inject a header into the configuration, which will automatically enable the `header_comment` fixer