### PR TITLE
Fix: Make it first target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
+it: cs test
+
 composer:
 	composer validate
 	composer install
 
 cs: composer
 	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff
-
-it: cs test
 
 test: composer
 	vendor/bin/phpunit --configuration=phpunit.xml


### PR DESCRIPTION
This PR

* [x] makes `it` the first target