### PR TITLE
Enhancement: Enable unary_operators_spaces fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -118,6 +118,7 @@ class Refinery29 extends Config
             'trim_array_spaces' => true,
             'unalign_double_arrow' => true,
             'unalign_equals' => true,
+            'unary_operators_spaces' => true,
             'unneeded_control_parentheses' => true,
             'unused_use' => true,
             'whitespacy_lines' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -237,6 +237,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'trim_array_spaces' => true,
             'unalign_double_arrow' => true,
             'unalign_equals' => true,
+            'unary_operators_spaces' => true,
             'unneeded_control_parentheses' => true,
             'unused_use' => true,
             'whitespacy_lines' => true,


### PR DESCRIPTION
This PR

* [x] enables the `unary_operators_spaces` fixer

:information_desk_person: See https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

> **unary_operators_spaces** [@Symfony]
Unary operators should be placed adjacent to their operands.


