### PR TITLE
Enhancement: Enable short_scalar_cast fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -107,6 +107,7 @@ class Refinery29 extends Config
             'return' => true,
             'self_accessor' => false,
             'short_bool_cast' => true,
+            'short_scalar_cast' => true,
             'single_array_no_trailing_comma' => true,
             'single_blank_line_before_namespace' => true,
             'single_quote' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -226,6 +226,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'return' => true,
             'self_accessor' => false,
             'short_bool_cast' => true,
+            'short_scalar_cast' => true,
             'single_array_no_trailing_comma' => true,
             'single_blank_line_before_namespace' => true,
             'single_quote' => true,


### PR DESCRIPTION
This PR

* [x] enables the `short_scalar_cast` fixer

:information_desk_person: See https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

> **short_scalar_cast** [@Symfony]
Cast "(boolean)" and "(integer)" should be written as "(bool)" and "(int)". "(double)" and "(real)" as "(float)".

