### PR TITLE
Enhancement: Enable native_function_casing fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -82,6 +82,7 @@ class Refinery29 extends Config
             'method_separation' => true,
             'multiline_array_trailing_comma' => true,
             'namespace_no_leading_whitespace' => true,
+            'native_function_casing' => true,
             'new_with_braces' => true,
             'no_blank_lines_after_class_opening' => true,
             'no_empty_lines_after_phpdocs' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -199,6 +199,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'method_separation' => true,
             'multiline_array_trailing_comma' => true,
             'namespace_no_leading_whitespace' => true,
+            'native_function_casing' => true,
             'new_with_braces' => true,
             'no_blank_lines_after_class_opening' => true,
             'no_empty_lines_after_phpdocs' => true,


### PR DESCRIPTION
This PR

* [x] enables the `native_function_casing` fixer

:information_desk_person: See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

> **native_function_casing** [`@Symfony`]
Function defined by PHP should be called using the correct casing.