### PR TITLE
Enhancement: Enable hash_to_slash_comment fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -78,6 +78,7 @@ class Refinery29 extends Config
             'empty_return' => true,
             'extra_empty_lines' => true,
             'include' => true,
+            'hash_to_slash_comment' => true,
             'list_commas' => true,
             'method_separation' => true,
             'multiline_array_trailing_comma' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -195,6 +195,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'empty_return' => true,
             'extra_empty_lines' => true,
             'include' => true,
+            'hash_to_slash_comment' => true,
             'list_commas' => true,
             'method_separation' => true,
             'multiline_array_trailing_comma' => true,


### PR DESCRIPTION
This PR

* [x] enables the `hash_to_slash_comment` fixer

:information_desk_person: See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

> **hash_to_slash_comment** [`@Symfony`]
Single line comments should use double slashes (//) and not hash (#).