### PR TITLE
Fix: Revert changes to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,10 @@ it: cs test
 
 composer:
 	composer validate
-	composer update
+	composer install
 
 cs: composer
 	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff
 
 test: composer
 	vendor/bin/phpunit --configuration=phpunit.xml
-	make cs


### PR DESCRIPTION
This PR

* [x] reverts changes to `Makefile`

Follows #41.