### PR TITLE
Enhancement: Enable no_useless_return fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -150,6 +150,7 @@ class Refinery29 extends Config
             'no_multiline_whitespaces_before_semicolon' => false,
             'no_php4_constructor' => false,
             'no_short_echo_tag' => true,
+            'no_useless_return' => true,
             'not_operators_with_space' => false,
             'not_operator_with_successor_space' => false,
             'ordered_imports' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -282,6 +282,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'no_multiline_whitespaces_before_semicolon' => false,
             'no_php4_constructor' => false,
             'no_short_echo_tag' => true,
+            'no_useless_return' => true,
             'not_operators_with_space' => false,
             'not_operator_with_successor_space' => false,
             'ordered_imports' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_useless_return` fixer

:information_desk_person: See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

> **no_useless_return**
There should not be an empty return statement at the end of a function.
