### PR TITLE
Fix: Update fabpot/php-cs-fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There are two possibilities here
 * you require that same commit in your repository
 
     ```
-    $ composer require fabpot/php-cs-fixer-config:dev-master#11088fb.
+    $ composer require fabpot/php-cs-fixer-config:dev-master#e8a84e3.
     ```
 
 * you configure `composer.json` in your root package with
@@ -41,7 +41,7 @@ There are two possibilities here
     ```
   trusting us to pull in a working version.
   
-For reference, see [`fabpot/php-cs-fixer-config:dev-master#11088fb`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/11088fb).
+For reference, see [`fabpot/php-cs-fixer-config:dev-master#e8a84e3`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/e8a84e3).
   
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^5.5 || ^7.0",
-        "fabpot/php-cs-fixer": "dev-master#11088fb"
+        "fabpot/php-cs-fixer": "dev-master#e8a84e3"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "0.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2ea8cb93792bec70daead05ade519f6f",
-    "content-hash": "59aca1c612eee3066c70acc3831e9a6b",
+    "hash": "5f3ad7936858abc28998c6f5b46d6575",
+    "content-hash": "4818d8b69da99d417082e69f7843079f",
     "packages": [
         {
             "name": "fabpot/php-cs-fixer",
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "11088fb"
+                "reference": "e8a84e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/11088fbb819088308d297c34860b3dde5411fc9a",
-                "reference": "11088fb",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/e8a84e3380ada463d9b0042e264200f9696e3cc7",
+                "reference": "e8a84e3",
                 "shasum": ""
             },
             "require": {
@@ -65,7 +65,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2016-02-15 23:01:28"
+            "time": "2016-02-24 08:08:33"
         },
         {
             "name": "sebastian/diff",

--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -70,8 +70,8 @@ class Refinery29 extends Config
         return [
             'blank_line_after_opening_tag' => true,
             'blank_line_before_return' => true,
+            'cast_spaces' => true,
             'concat_without_spaces' => false,
-            'double_arrow_no_multiline_whitespace' => true,
             'function_typehint_space' => true,
             'hash_to_slash_comment' => true,
             'heredoc_to_nowdoc' => false,
@@ -88,6 +88,7 @@ class Refinery29 extends Config
             'no_extra_consecutive_blank_lines' => true,
             'no_leading_import_slash' => true,
             'no_leading_namespace_whitespace' => true,
+            'no_multiline_whitespace_around_double_arrow' => true,
             'no_short_bool_cast' => true,
             'no_singleline_whitespace_before_semicolons' => true,
             'no_trailing_comma_in_list_call' => true,
@@ -120,7 +121,6 @@ class Refinery29 extends Config
             'single_blank_line_before_namespace' => true,
             'single_quote' => true,
             'space_after_semicolon' => true,
-            'spaces_cast' => true,
             'standardize_not_equals' => true,
             'ternary_operator_spaces' => true,
             'trailing_comma_in_multiline_array' => true,
@@ -161,7 +161,7 @@ class Refinery29 extends Config
             'php_unit_strict' => false,
             'psr0' => false,
             'short_array_syntax' => true,
-            'strict' => false,
+            'strict_comparison' => false,
             'strict_param' => false,
         ];
 

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -168,7 +168,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'php_unit_strict' => 'it changes behaviour',
             'print_to_echo' => 'we have not decided to use this one (yet)',
             'psr0' => 'we are using PSR-4',
-            'strict' => 'it changes behaviour',
+            'strict_comparison' => 'it changes behaviour',
             'strict_param' => 'it changes behaviour',
         ];
 
@@ -202,8 +202,8 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
         return [
             'blank_line_after_opening_tag' => true,
             'blank_line_before_return' => true,
+            'cast_spaces' => true,
             'concat_without_spaces' => false,
-            'double_arrow_no_multiline_whitespace' => true,
             'function_typehint_space' => true,
             'hash_to_slash_comment' => true,
             'heredoc_to_nowdoc' => false,
@@ -220,6 +220,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'no_extra_consecutive_blank_lines' => true,
             'no_leading_import_slash' => true,
             'no_leading_namespace_whitespace' => true,
+            'no_multiline_whitespace_around_double_arrow' => true,
             'no_short_bool_cast' => true,
             'no_singleline_whitespace_before_semicolons' => true,
             'no_trailing_comma_in_list_call' => true,
@@ -252,7 +253,6 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'single_blank_line_before_namespace' => true,
             'single_quote' => true,
             'space_after_semicolon' => true,
-            'spaces_cast' => true,
             'standardize_not_equals' => true,
             'ternary_operator_spaces' => true,
             'trailing_comma_in_multiline_array' => true,
@@ -293,7 +293,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'php_unit_strict' => false,
             'psr0' => false,
             'short_array_syntax' => true,
-            'strict' => false,
+            'strict_comparison' => false,
             'strict_param' => false,
         ];
     }


### PR DESCRIPTION
This PR

* [x] updates `fabpot/php-cs-fixer`
* [x] updates configuration following the renaming of fixers (see https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/79067fb7ee5a4a2be8f0faa52bed3dd2a8aa1555)

For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/compare/11088fb...e8a84e3380ada463d9b0042e264200f9696e3cc7.