### PR TITLE
Fix: Enable combine_consecutive_unsets fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -140,6 +140,7 @@ class Refinery29 extends Config
         $rules = [
             'align_double_arrow' => false,
             'align_equals' => false,
+            'combine_consecutive_unsets' => true,
             'concat_with_spaces' => true,
             'ereg_to_preg' => false,
             'echo_to_print' => false,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -203,6 +203,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'blank_line_after_opening_tag' => true,
             'blank_line_before_return' => true,
             'cast_spaces' => true,
+            'combine_consecutive_unsets' => true,
             'concat_without_spaces' => false,
             'function_typehint_space' => true,
             'hash_to_slash_comment' => true,


### PR DESCRIPTION
This PR

* [x] enables the `combine_consecutive_unsets` fixer

:information_desk_person: See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

> **combine_consecutive_unsets**
>Calling unset on multiple items should be done in one call.