### PR TITLE
Enhancement: Enable phpdoc_single_line_var_spacing fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -107,6 +107,7 @@ class Refinery29 extends Config
             'phpdoc_no_package' => true,
             'phpdoc_scalar' => true,
             'phpdoc_separation' => true,
+            'phpdoc_single_line_var_spacing' => true,
             'phpdoc_summary' => false,
             'phpdoc_to_comment' => true,
             'phpdoc_trim' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -239,6 +239,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'phpdoc_no_package' => true,
             'phpdoc_scalar' => true,
             'phpdoc_separation' => true,
+            'phpdoc_single_line_var_spacing' => true,
             'phpdoc_summary' => false,
             'phpdoc_to_comment' => true,
             'phpdoc_trim' => true,


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_single_line_var_spacing` fixer

:information_desk_person: See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

> **phpdoc_single_line_var_spacing [`@Symfony`]**
>Single line `@var` PHPDoc should have proper spacing.