### PR TITLE
Enhancement: Enable no_empty_comment fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -6,6 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
+
 namespace Refinery29\CS\Config;
 
 use PhpCsFixer\Config;

--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -150,6 +150,7 @@ class Refinery29 extends Config
             'long_array_syntax' => false,
             'modernize_types_casting' => false,
             'no_blank_lines_before_namespace' => true,
+            'no_empty_comment' => true,
             'no_multiline_whitespaces_before_semicolon' => false,
             'no_php4_constructor' => false,
             'no_short_echo_tag' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -6,6 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
+
 namespace Refinery29\CS\Config\Test;
 
 use PhpCsFixer\ConfigInterface;

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -284,6 +284,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'linebreak_after_opening_tag' => true,
             'long_array_syntax' => false,
             'no_blank_lines_before_namespace' => true,
+            'no_empty_comment' => true,
             'no_multiline_whitespaces_before_semicolon' => false,
             'no_php4_constructor' => false,
             'no_short_echo_tag' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_empty_comment` fixer
* [x] runs `make cs`

:information_desk_person: See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

>**no_empty_comment**
>There should not be an empty comments.

