### PR TITLE
Fix: Update fabpot/php-cs-fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There are two possibilities here
 * you require that same commit in your repository
 
     ```
-    $ composer require fabpot/php-cs-fixer-config:dev-master#535e239.
+    $ composer require fabpot/php-cs-fixer-config:dev-master#8c3f299.
     ```
 
 * you configure `composer.json` in your root package with
@@ -41,7 +41,7 @@ There are two possibilities here
     ```
   trusting us to pull in a working version.
   
-For reference, see [`fabpot/php-cs-fixer-config:dev-master#535e239`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/535e239).
+For reference, see [`fabpot/php-cs-fixer-config:dev-master#8c3f299`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/8c3f299).
   
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^5.5 || ^7.0",
-        "fabpot/php-cs-fixer": "dev-master#535e239"
+        "fabpot/php-cs-fixer": "dev-master#8c3f299"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "0.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "405b61b3233eeebdf660929231c505b8",
-    "content-hash": "a7df83d801cf31727af50553c7388103",
+    "hash": "3ff0d8af296b815e7a288ec179149799",
+    "content-hash": "b4f42ca15605528ec29e5c5010296734",
     "packages": [
         {
             "name": "fabpot/php-cs-fixer",
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "535e239"
+                "reference": "8c3f299"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/535e23906808f74c0d077cfa76e436cfc409e712",
-                "reference": "535e239",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/8c3f29998f200cc9fc59c823aeb1eb0f26ba6b76",
+                "reference": "8c3f299",
                 "shasum": ""
             },
             "require": {
@@ -65,7 +65,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2016-03-13 17:41:28"
+            "time": "2016-04-05 07:15:34"
         },
         {
             "name": "sebastian/diff",


### PR DESCRIPTION
This PR

* [x] updates `fabpot/php-cs-fixer`

💁 For reference, see http://github.com/FriendsOfPHP/PHP-CS-Fixer/compare/535e239...8c3f299.