### PR TITLE
Enhancement: Enable no_empty_statement fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -85,6 +85,7 @@ class Refinery29 extends Config
             'no_blank_lines_after_phpdoc' => true,
             'no_blank_lines_between_uses' => true,
             'no_duplicate_semicolons' => true,
+            'no_empty_statement' => true,
             'no_extra_consecutive_blank_lines' => true,
             'no_leading_import_slash' => true,
             'no_leading_namespace_whitespace' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -222,6 +222,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'no_blank_lines_after_phpdoc' => true,
             'no_blank_lines_between_uses' => true,
             'no_duplicate_semicolons' => true,
+            'no_empty_statement' => true,
             'no_extra_consecutive_blank_lines' => true,
             'no_leading_import_slash' => true,
             'no_leading_namespace_whitespace' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_empty_statement` fixer

Follows #76.

:information_desk_person: See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

> **no_empty_statement** [`@Symfony`]
> Remove useless semicolon statements.
