### PR TITLE
Fix: Reduce visibility

### DIFF
--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -274,7 +274,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
     /**
      * @return array
      */
-    protected function getContribRules()
+    private function getContribRules()
     {
         return [
             'align_double_arrow' => false,


### PR DESCRIPTION
This PR

* [x] reduces the visibility of a method from `protected`  to `private`
