### PR TITLE
Enhancement: Enable no_spaces_inside_offset fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -92,6 +92,7 @@ class Refinery29 extends Config
             'no_multiline_whitespace_around_double_arrow' => true,
             'no_short_bool_cast' => true,
             'no_singleline_whitespace_before_semicolons' => true,
+            'no_spaces_inside_offset' => true,
             'no_trailing_comma_in_list_call' => true,
             'no_trailing_comma_in_singleline_array' => true,
             'no_unneeded_control_parentheses' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -230,6 +230,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'no_multiline_whitespace_around_double_arrow' => true,
             'no_short_bool_cast' => true,
             'no_singleline_whitespace_before_semicolons' => true,
+            'no_spaces_inside_offset' => true,
             'no_trailing_comma_in_list_call' => true,
             'no_trailing_comma_in_singleline_array' => true,
             'no_unneeded_control_parentheses' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_spaces_inside_offset` fixer

Follows #82.
Follows https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1861.

💁 See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

> **no_spaces_inside_offset** [`@Symfony`]
> There MUST NOT be spaces between the offset square braces and its contained values.