### PR TITLE
Fix: Update fabpot/php-cs-fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,33 +15,6 @@ Run
 ```
 $ composer require --dev refinery29/php-cs-fixer-config
 ```
-
-:exclamation: Since `fabpot/php-cs-fixer:2.0.x-dev` isn't stable, we're pinning the dependency to a known commit. 
-
-There are two possibilities here
- 
-* you require that same commit in your repository
-
-    ```
-    $ composer require fabpot/php-cs-fixer-config:dev-master#62898ea.
-    ```
-
-* you configure `composer.json` in your root package with
-
-    ```json
-    {
-        "minimum-stability": "dev",
-        "prefer-stable": true
-    }
-    ```
-  and remove `fabpot/php-cs-fixer` with
-  
-    ```
-    $ composer remove fabpot/php-cs-fixer
-    ```
-  trusting us to pull in a working version.
-  
-For reference, see [`fabpot/php-cs-fixer-config:dev-master#62898ea`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/62898ea).
   
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^5.5 || ^7.0",
-        "fabpot/php-cs-fixer": "dev-master#62898ea"
+        "fabpot/php-cs-fixer": "2.0.0-alpha"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "0.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "20e0e4e7e0f5a2a65cb1092b1d1baac2",
-    "content-hash": "39d571fe5c33d615fa6a241e05e0d6db",
+    "hash": "aad8f5f02d29aa2de2181139218f4b35",
+    "content-hash": "786ab9577b82026341adfcd31949f88b",
     "packages": [
         {
             "name": "fabpot/php-cs-fixer",
-            "version": "dev-master",
+            "version": "v2.0.0-alpha",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "62898ea"
+                "reference": "d0d76b434728fcf522270b67b454ed7e84e850ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/62898ea",
-                "reference": "62898ea",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/d0d76b434728fcf522270b67b454ed7e84e850ed",
+                "reference": "d0d76b434728fcf522270b67b454ed7e84e850ed",
                 "shasum": ""
             },
             "require": {
@@ -65,7 +65,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2016-05-19 19:19:42"
+            "time": "2016-05-26 23:59:22"
         },
         {
             "name": "sebastian/diff",
@@ -1761,7 +1761,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "fabpot/php-cs-fixer": 20
+        "fabpot/php-cs-fixer": 15
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -83,8 +83,6 @@ class Refinery29 extends Config
             'no_alias_functions' => true,
             'no_blank_lines_after_class_opening' => true,
             'no_blank_lines_after_phpdoc' => true,
-            'no_blank_lines_between_uses' => true,
-            'no_duplicate_semicolons' => true,
             'no_empty_statement' => true,
             'no_extra_consecutive_blank_lines' => true,
             'no_leading_import_slash' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -221,8 +221,6 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'no_alias_functions' => true,
             'no_blank_lines_after_class_opening' => true,
             'no_blank_lines_after_phpdoc' => true,
-            'no_blank_lines_between_uses' => true,
-            'no_duplicate_semicolons' => true,
             'no_empty_statement' => true,
             'no_extra_consecutive_blank_lines' => true,
             'no_leading_import_slash' => true,


### PR DESCRIPTION
This PR

* [x] updates `fabpot/php-cs-fixer`
* [x] removes renamed fixers (`no_blank_lines_between_uses` and `no_duplicate_semicolons `)
 
💁 For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/compare/62898ea...v2.0.0-alpha.