### PR TITLE
Fix: Update fabpot/php-cs-fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There are two possibilities here
 * you require that same commit in your repository
 
     ```
-    $ composer require fabpot/php-cs-fixer-config:dev-master#8548d19.
+    $ composer require fabpot/php-cs-fixer-config:dev-master#62898ea.
     ```
 
 * you configure `composer.json` in your root package with
@@ -41,7 +41,7 @@ There are two possibilities here
     ```
   trusting us to pull in a working version.
   
-For reference, see [`fabpot/php-cs-fixer-config:dev-master#8548d19`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/8548d19).
+For reference, see [`fabpot/php-cs-fixer-config:dev-master#62898ea`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/62898ea).
   
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^5.5 || ^7.0",
-        "fabpot/php-cs-fixer": "dev-master#8548d19"
+        "fabpot/php-cs-fixer": "dev-master#62898ea"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "0.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3012a9ba94e872abe9f2640f87ad5606",
-    "content-hash": "bee2c6352ff30e9d81c2d8819a31380f",
+    "hash": "20e0e4e7e0f5a2a65cb1092b1d1baac2",
+    "content-hash": "39d571fe5c33d615fa6a241e05e0d6db",
     "packages": [
         {
             "name": "fabpot/php-cs-fixer",
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "8548d19"
+                "reference": "62898ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/8548d19d477bb9f782b1a34d741721bb8a79cd4a",
-                "reference": "8548d19",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/62898ea",
+                "reference": "62898ea",
                 "shasum": ""
             },
             "require": {
@@ -27,7 +27,7 @@
                 "sebastian/diff": "^1.1",
                 "symfony/console": "^2.3 || ^3.0",
                 "symfony/event-dispatcher": "^2.1 || ^3.0",
-                "symfony/filesystem": "^2.1 || ^3.0",
+                "symfony/filesystem": "^2.7 || ^3.0",
                 "symfony/finder": "^2.2 || ^3.0",
                 "symfony/polyfill-php54": "^1.0",
                 "symfony/process": "^2.3 || ^3.0",
@@ -65,7 +65,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2016-04-17 21:27:07"
+            "time": "2016-05-19 19:19:42"
         },
         {
             "name": "sebastian/diff",


### PR DESCRIPTION
This PR

* [x] updates `fabpot/php-cs-fixer`

Follows https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1888.

💁 Back to caching when performing a `--dry-run`!

For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/compare/8548d19...62898ea.