### PR TITLE
Enhancement: Enable no_useless_else fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -155,6 +155,7 @@ class Refinery29 extends Config
             'no_multiline_whitespaces_before_semicolon' => false,
             'no_php4_constructor' => false,
             'no_short_echo_tag' => true,
+            'no_useless_else' => true,
             'no_useless_return' => true,
             'not_operators_with_space' => false,
             'not_operator_with_successor_space' => false,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -291,6 +291,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'no_multiline_whitespaces_before_semicolon' => false,
             'no_php4_constructor' => false,
             'no_short_echo_tag' => true,
+            'no_useless_else' => true,
             'no_useless_return' => true,
             'not_operators_with_space' => false,
             'not_operator_with_successor_space' => false,


### PR DESCRIPTION
This PR

* [x] enables the `no_useless_else` fixer

Follows #89.

💁 See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

>`no_useless_else`
>There should not be useless else cases.