### PR TITLE
Fix: Enable phpdoc_summary fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -108,7 +108,7 @@ class Refinery29 extends Config
             'phpdoc_scalar' => true,
             'phpdoc_separation' => true,
             'phpdoc_single_line_var_spacing' => true,
-            'phpdoc_summary' => false,
+            'phpdoc_summary' => true,
             'phpdoc_to_comment' => true,
             'phpdoc_trim' => true,
             'phpdoc_type_to_var' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -171,7 +171,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'phpdoc_scalar' => true,
             'phpdoc_separation' => true,
             'phpdoc_single_line_var_spacing' => true,
-            'phpdoc_summary' => false, // have not decided to use this one (yet)
+            'phpdoc_summary' => true,
             'phpdoc_to_comment' => true,
             'phpdoc_trim' => true,
             'phpdoc_type_to_var' => true,


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_summary` fixer

💁 For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage.

>**phpdoc_summary** [`@Symfony`]
>Phpdocs summary should end in either a full stop, exclamation mark, or question mark.
