### PR TITLE
Enhancement: Enable no_multiline_whitespace_before_semicolons fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -152,7 +152,7 @@ class Refinery29 extends Config
             'modernize_types_casting' => false,
             'no_blank_lines_before_namespace' => false,
             'no_empty_comment' => true,
-            'no_multiline_whitespace_before_semicolons' => false,
+            'no_multiline_whitespace_before_semicolons' => true,
             'no_php4_constructor' => false,
             'no_short_echo_tag' => true,
             'no_useless_else' => false,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -215,7 +215,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'modernize_types_casting' => false, // risky
             'no_blank_lines_before_namespace' => false, // conflicts with single_blank_line_before_namespace (which is enabled)
             'no_empty_comment' => true,
-            'no_multiline_whitespace_before_semicolons' => false, // have not decided to use this one (yet)
+            'no_multiline_whitespace_before_semicolons' => true,
             'no_php4_constructor' => false, // risky
             'no_short_echo_tag' => true,
             'no_useless_else' => false, // has issues with edge cases, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1923


### PR DESCRIPTION
This PR

* [x] enables the `no_multiline_whitespace_before_semicolons` fixer

💁 See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

> `no_multiline_whitespace_before_semicolons`
> Multi-line whitespace before closing semicolon are prohibited.