### PR TITLE
Enhancement: Enable binary_operator_spaces fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -68,6 +68,7 @@ class Refinery29 extends Config
     private function getSymfonyRules()
     {
         return [
+            'binary_operator_spaces' => true,
             'blank_line_after_opening_tag' => true,
             'blank_line_before_return' => true,
             'cast_spaces' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -131,6 +131,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
     private function getSymfonyRules()
     {
         return [
+            'binary_operator_spaces' => true,
             'blank_line_after_opening_tag' => true,
             'blank_line_before_return' => true,
             'cast_spaces' => true,


### PR DESCRIPTION
This PR

* [x] enables the `binary_operator_spaces` fixer

💁 See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

> `binary_operator_spaces` [`@Symfony`]
> Binary operators should be surrounded by at least one space.

For examples, see [`BinaryOperatorSpacesFixerTest`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php).