### PR TITLE
Enhancement: Enable no_empty_phpdoc fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -84,6 +84,7 @@ class Refinery29 extends Config
             'no_alias_functions' => true,
             'no_blank_lines_after_class_opening' => true,
             'no_blank_lines_after_phpdoc' => true,
+            'no_empty_phpdoc' => true,
             'no_empty_statement' => true,
             'no_extra_consecutive_blank_lines' => true,
             'no_leading_import_slash' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -147,6 +147,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'no_alias_functions' => true,
             'no_blank_lines_after_class_opening' => true,
             'no_blank_lines_after_phpdoc' => true,
+            'no_empty_phpdoc' => true,
             'no_empty_statement' => true,
             'no_extra_consecutive_blank_lines' => true,
             'no_leading_import_slash' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_empty_phpdoc` fixer

💁 See https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

> `no_empty_phpdoc` [`@Symfony`]
> There should not be empty PHPDoc blocks.
