### PR TITLE
Fix: Return rules from a single method

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -45,29 +45,8 @@ class Refinery29 extends Config
 
     public function getRules()
     {
-        return array_merge(
-            $this->getPsr2Rules(),
-            $this->getSymfonyRules(),
-            $this->getContribRules()
-        );
-    }
-
-    /**
-     * @return array
-     */
-    private function getPsr2Rules()
-    {
-        return [
+        $rules = [
             '@PSR2' => true,
-        ];
-    }
-
-    /**
-     * @return array
-     */
-    private function getSymfonyRules()
-    {
-        return [
             'binary_operator_spaces' => true,
             'blank_line_after_opening_tag' => true,
             'blank_line_before_return' => true,
@@ -132,15 +111,6 @@ class Refinery29 extends Config
             'unalign_equals' => true,
             'unary_operator_spaces' => true,
             'whitespace_after_comma_in_array' => true,
-        ];
-    }
-
-    /**
-     * @return array
-     */
-    private function getContribRules()
-    {
-        $rules = [
             'align_double_arrow' => false,
             'align_equals' => false,
             'combine_consecutive_unsets' => true,


### PR DESCRIPTION
This PR

* [x] merges `private` methods aggregating rules

💁‍♂️ This is to prepare for updating to [`friendsofphp-php-cs-fixer:2.0.0-RC`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/tag/v2.0.0-RC). The reason is that rules have been moved from different rule sets to others, and in the end, we don't care much about to which ruleset they belong (that is, other than `@PSR2`, because we use this as a base), as long as the fixers are enabled.