### PR TITLE
Fix: Actually remove method

### DIFF
--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -80,14 +80,6 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param array $expected
-     * @param array $actual
-     */
-    private function assertHasRules(array $expected, array $actual)
-    {
-    }
-
-    /**
      * @return array
      */
     private function getRules()


### PR DESCRIPTION
This PR

* [x] removes a method which should have been removed earlier, actually

Follows #109.

