### PR TITLE
Fix: Cache is used by default

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -28,12 +28,7 @@ class Refinery29 extends Config
         $this->header = $header;
     }
 
-    public function usingCache()
-    {
-        return true;
-    }
-
-    public function usingLinter()
+    public function getUsingCache()
     {
         return true;
     }

--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -26,16 +26,8 @@ class Refinery29 extends Config
         parent::__construct('refinery29');
 
         $this->header = $header;
-    }
 
-    public function getUsingCache()
-    {
-        return true;
-    }
-
-    public function getRiskyAllowed()
-    {
-        return true;
+        $this->setRiskyAllowed(true);
     }
 
     public function getRules()

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -28,8 +28,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
         $config = new Refinery29();
 
         $this->assertSame('refinery29', $config->getName());
-        $this->assertTrue($config->usingCache());
-        $this->assertTrue($config->usingLinter());
+        $this->assertTrue($config->getUsingCache());
         $this->assertTrue($config->getRiskyAllowed());
     }
 


### PR DESCRIPTION
This PR

* [x] rename `usingCache()` to `getUsingCache()`
* [x] simplifies setting up configuration defaults
