### PR TITLE
Enhancement: Enable no_useless_else fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -90,7 +90,7 @@ class Refinery29 extends Config
             'no_unneeded_control_parentheses' => true,
             'no_unreachable_default_argument_value' => true,
             'no_unused_imports' => true,
-            'no_useless_else' => false,
+            'no_useless_else' => true,
             'no_useless_return' => true,
             'no_whitespace_before_comma_in_array' => true,
             'no_whitespace_in_blank_line' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -190,7 +190,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'no_unneeded_control_parentheses' => true,
             'no_unreachable_default_argument_value' => true,
             'no_unused_imports' => true,
-            'no_useless_else' => false, // has issues with edge cases, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1923
+            'no_useless_else' => true,
             'no_useless_return' => true,
             'no_whitespace_before_comma_in_array' => true,
             'no_whitespace_in_blank_line' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_useless_else` fixer

Follows #93.
Follows https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1926.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

> `no_useless_else`
> There should not be useless else cases.