### PR TITLE
Enhancement: Enable normalize_index_brace fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -94,7 +94,7 @@ class Refinery29 extends Config
             'no_useless_return' => true,
             'no_whitespace_before_comma_in_array' => true,
             'no_whitespace_in_blank_line' => true,
-            'normalize_index_brace' => false,
+            'normalize_index_brace' => true,
             'not_operator_with_space' => false,
             'not_operator_with_successor_space' => false,
             'object_operator_without_whitespace' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -194,7 +194,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'no_useless_return' => true,
             'no_whitespace_before_comma_in_array' => true,
             'no_whitespace_in_blank_line' => true,
-            'normalize_index_brace' => false, // have not decided to use this one (yet)
+            'normalize_index_brace' => true,
             'not_operator_with_space' => false, // have decided not to use it
             'not_operator_with_successor_space' => false, // have decided not to use it
             'object_operator_without_whitespace' => true,


### PR DESCRIPTION
This PR

* [x] enables the `normalize_index_brace` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master#usage:

> `normalize_index_brace [@Symfony]`
> Array index should always be written by using square braces.