### PR TITLE
Enhancement: Enable php_unit_fcqn_annotation fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -102,7 +102,7 @@ class Refinery29 extends Config
             'ordered_imports' => true,
             'php_unit_construct' => false,
             'php_unit_dedicate_assert' => false,
-            'php_unit_fqcn_annotation' => false,
+            'php_unit_fqcn_annotation' => true,
             'php_unit_strict' => false,
             'phpdoc_align' => true,
             'phpdoc_annotation_without_dot' => false,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -202,7 +202,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'ordered_imports' => true,
             'php_unit_construct' => false, // risky
             'php_unit_dedicate_assert' => false, // risky
-            'php_unit_fqcn_annotation' => false, // have not decided to use this one (yet)
+            'php_unit_fqcn_annotation' => true,
             'php_unit_strict' => false, // risky
             'phpdoc_align' => true,
             'phpdoc_annotation_without_dot' => false, // have not decided to use this one (yet)


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_fcqn_annotation` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/README.rst#usage:

> `php_unit_fqcn_annotation [@Symfony]`
> PHPUnit @expectedException annotation should be a FQCN including a root
namespace.
