### PR TITLE
Enhancement: Enable return_type_declaration fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -130,7 +130,7 @@ class Refinery29 extends Config
             'psr0' => false,
             'psr4' => false,
             'random_api_migration' => false,
-            'return_type_declaration' => false,
+            'return_type_declaration' => true,
             'self_accessor' => false,
             'semicolon_after_instruction' => false,
             'short_scalar_cast' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -230,7 +230,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'psr0' => false, // using PSR-4
             'psr4' => false, // have not decided to use this one (yet)
             'random_api_migration' => false, // risky
-            'return_type_declaration' => false, // have not decided to use this one (yet)
+            'return_type_declaration' => true,
             'self_accessor' => false, // it causes an edge case error
             'semicolon_after_instruction' => false, // have not decided to use this one (yet)
             'short_scalar_cast' => true,


### PR DESCRIPTION
This PR

* [x] enables the `return_type_declaration ` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master#usage:

> `return_type_declaration [@Symfony]`
> There should be no space before colon and one space after it in return
type declaration.