### PR TITLE
Enhancement: Enable semicolon_after_instruction fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -132,7 +132,7 @@ class Refinery29 extends Config
             'random_api_migration' => false,
             'return_type_declaration' => false,
             'self_accessor' => false,
-            'semicolon_after_instruction' => false,
+            'semicolon_after_instruction' => true,
             'short_scalar_cast' => true,
             'silenced_deprecation_error' => false,
             'simplified_null_return' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -232,7 +232,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'random_api_migration' => false, // risky
             'return_type_declaration' => false, // have not decided to use this one (yet)
             'self_accessor' => false, // it causes an edge case error
-            'semicolon_after_instruction' => false, // have not decided to use this one (yet)
+            'semicolon_after_instruction' => true,
             'short_scalar_cast' => true,
             'silenced_deprecation_error' => false, // have not decided to use this one (yet)
             'simplified_null_return' => true,


### PR DESCRIPTION
This PR

* [x] enables the `semicolon_after_instruction` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master#usage:

> `semicolon_after_instruction`
> Instructions must be terminated with a semicolon.