### PR TITLE
Enhancement: Enable declare_strict fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -50,7 +50,7 @@ class Refinery29 extends Config
                 'spacing' => 'one',
             ],
             'declare_equal_normalize' => false,
-            'declare_strict_types' => false,
+            'declare_strict_types' => true,
             'dir_constant' => false,
             'ereg_to_preg' => false,
             'function_typehint_space' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -148,7 +148,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
                 'spacing' => 'one',
             ],
             'declare_equal_normalize' => false,
-            'declare_strict_types' => false,  // have not decided to use this one (yet)
+            'declare_strict_types' => true,
             'dir_constant' => false, // risky
             'ereg_to_preg' => false, // risky
             'function_typehint_space' => true,


### PR DESCRIPTION
This PR

* [x] enables the `declare_strict_types` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

> **declare_strict_types**
> Force strict types declaration in all files. Requires PHP >= 7.0.
> Rule is: risky.