### PR TITLE
Fix: Run php-cs-fixer on PHP 5.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ matrix:
   include:
     - php: 5.5
     - php: 5.6
-    - php: 7.0
       env: WITH_CS=true
+    - php: 7.0
     - php: 7.1
       env: WITH_COVERAGE=true
 


### PR DESCRIPTION
This PR

* [x] runs `php-cs-fixer` on PHP 5.6 instead of PHP 7 on Travis

Blocks #130.

💁‍♂️ The idea is this: `php-cs-fixer` itself only applies fixers targeted at PHP 7 when the version it is run in is PHP 7. If we let it run on a version below that, `refinery29/php-cs-fixer-config` can be compatible to that version. PHP 7 features aren't really required for `refinery29/php-cs-fixer-config`, but we want to enable fixers for code that runs on PHP 7 only. 