### PR TITLE
Enhancement: Enable declare_equal_normalize fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -49,7 +49,7 @@ class Refinery29 extends Config
             'concat_space' => [
                 'spacing' => 'one',
             ],
-            'declare_equal_normalize' => false,
+            'declare_equal_normalize' => true,
             'declare_strict_types' => true,
             'dir_constant' => false,
             'ereg_to_preg' => false,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -147,7 +147,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'concat_space' => [
                 'spacing' => 'one',
             ],
-            'declare_equal_normalize' => false,
+            'declare_equal_normalize' => true,
             'declare_strict_types' => true,
             'dir_constant' => false, // risky
             'ereg_to_preg' => false, // risky


### PR DESCRIPTION
This PR

* [x] enables the `declare_equal_normalize` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

> **declare_equal_normalize [`@Symfony`]**
Equal sign in declare statement should not be surrounded by spaces.