### PR TITLE
Enhancement: Enable no_mixed_echo_print fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -76,7 +76,9 @@ class Refinery29 extends Config
             'no_extra_consecutive_blank_lines' => true,
             'no_leading_import_slash' => true,
             'no_leading_namespace_whitespace' => true,
-            'no_mixed_echo_print' => false,
+            'no_mixed_echo_print' => [
+                'use' => 'echo',
+            ],
             'no_multiline_whitespace_around_double_arrow' => true,
             'no_multiline_whitespace_before_semicolons' => true,
             'no_php4_constructor' => false,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -174,7 +174,9 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'no_extra_consecutive_blank_lines' => true,
             'no_leading_import_slash' => true,
             'no_leading_namespace_whitespace' => true,
-            'no_mixed_echo_print' => false, // have decided not to use it
+            'no_mixed_echo_print' => [
+                'use' => 'echo',
+            ],
             'no_multiline_whitespace_around_double_arrow' => true,
             'no_multiline_whitespace_before_semicolons' => true,
             'no_php4_constructor' => false, // risky


### PR DESCRIPTION
This PR

* [x] enables the `no_mixed_echo_print` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

> **no_mixed_echo_print** `[@Symfony]`
Either language construct print or echo should be used.
Rule is: configurable.