### PR TITLE
Enhancement: Enable phpdoc_add_missing_param_annotation fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -105,7 +105,9 @@ class Refinery29 extends Config
             'php_unit_dedicate_assert' => false,
             'php_unit_fqcn_annotation' => true,
             'php_unit_strict' => false,
-            'phpdoc_add_missing_param_annotation' => false,
+            'phpdoc_add_missing_param_annotation' => [
+                'only_untyped' => false,
+            ],
             'phpdoc_align' => true,
             'phpdoc_annotation_without_dot' => false,
             'phpdoc_indent' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -203,7 +203,9 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'php_unit_dedicate_assert' => false, // risky
             'php_unit_fqcn_annotation' => true,
             'php_unit_strict' => false, // risky
-            'phpdoc_add_missing_param_annotation' => false, // have not decided to use this one (yet)
+            'phpdoc_add_missing_param_annotation' => [
+                'only_untyped' => false,
+            ],
             'phpdoc_align' => true,
             'phpdoc_annotation_without_dot' => false, // have not decided to use this one (yet)
             'phpdoc_indent' => true,


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_add_missing_param_annotation` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

> `phpdoc_add_missing_param_annotation`
Phpdoc should contain `@param` for all params.
Rule is: configurable.