### PR TITLE
Enhancement: Enable protected_to_private fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -140,7 +140,7 @@ class Refinery29 extends Config
             'phpdoc_var_without_name' => true,
             'pow_to_exponentiation' => false,
             'pre_increment' => true,
-            'protected_to_private' => false,
+            'protected_to_private' => true,
             'psr0' => false,
             'psr4' => false,
             'random_api_migration' => false,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -238,7 +238,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'phpdoc_var_without_name' => true,
             'pow_to_exponentiation' => false, // have not decided to use this one (yet)
             'pre_increment' => true,
-            'protected_to_private' => false, // have not decided to use this one (yet)
+            'protected_to_private' => true,
             'psr0' => false, // using PSR-4
             'psr4' => false, // have not decided to use this one (yet)
             'random_api_migration' => false, // risky


### PR DESCRIPTION
This PR

* [x] enables the `protected_to_private` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

> `protected_to_private`
Converts protected variables and methods to private where possible.