### PR TITLE
Fix: Keep packages sorted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
             "email": "andreas.moller@refinery29.com"
         }
     ],
+    "config": {
+        "sort-packages": true
+    },
     "require": {
         "php": "^5.5 || ^7.0",
         "friendsofphp/php-cs-fixer": "^2.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0c73f2bdcae10709e30bec5f0c3b1747",
+    "hash": "e56583c21fd5d8b15bf7bffefcf55e13",
     "content-hash": "6b846c805a04d92555c2ee18cafa2165",
     "packages": [
         {


### PR DESCRIPTION
This PR

* [x] keeps packages in `composer.json` sorted

💁‍♂️ For reference, see https://getcomposer.org/doc/06-config.md#sort-packages.