### PR TITLE
Fix: Remove need to resolve global function in current namespace

### DIFF
--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -41,27 +41,27 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
 
     public function testAllConfiguredRulesAreBuiltIn()
     {
-        $fixersNotBuiltIn = array_diff(
+        $fixersNotBuiltIn = \array_diff(
             $this->configuredFixers(),
             $this->builtInFixers()
         );
 
-        $this->assertEmpty($fixersNotBuiltIn, sprintf(
+        $this->assertEmpty($fixersNotBuiltIn, \sprintf(
             'Failed to assert that fixers for the rules "%s" are built in',
-            implode('", "', $fixersNotBuiltIn)
+            \implode('", "', $fixersNotBuiltIn)
         ));
     }
 
     public function testAllBuiltInRulesAreConfigured()
     {
-        $fixersWithoutConfiguration = array_diff(
+        $fixersWithoutConfiguration = \array_diff(
             $this->builtInFixers(),
             $this->configuredFixers()
         );
 
-        $this->assertEmpty($fixersWithoutConfiguration, sprintf(
+        $this->assertEmpty($fixersWithoutConfiguration, \sprintf(
             'Failed to assert that built-in fixers for the rules "%s" are configured',
-            implode('", "', $fixersWithoutConfiguration)
+            \implode('", "', $fixersWithoutConfiguration)
         ));
     }
 
@@ -76,7 +76,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
         $reflection = new \ReflectionProperty(FixerFactory::class, 'fixersByName');
         $reflection->setAccessible(true);
 
-        return array_keys($reflection->getValue($fixerFactory));
+        return \array_keys($reflection->getValue($fixerFactory));
     }
 
     /**
@@ -91,11 +91,11 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
          *
          * @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2361
          */
-        $rules = array_map(function () {
+        $rules = \array_map(function () {
             return true;
         }, $config->getRules());
 
-        return array_keys(RuleSet::create($rules)->getRules());
+        return \array_keys(RuleSet::create($rules)->getRules());
     }
 
     public function testDoesNotHaveHeaderCommentFixerByDefault()


### PR DESCRIPTION
This PR

* [x] removes the need to look up global functions in current namespace

Follows https://github.com/refinery29/test-util/pull/126.

💁‍♂️ For reference, see 

* https://twitter.com/Ocramius/status/811504929357660160
* http://php.net/manual/en/language.namespaces.faq.php#language.namespaces.faq.shortname2
* http://veewee.github.io/blog/optimizing-php-performance-by-fq-function-calls/

>Function or constant names that do not contain a backslash like name can be resolved in 2 different ways.
>
>First, the current namespace name is prepended to _name_.
>
>Finally, if the constant or function _name_ does not exist in the current namespace, a global constant or function _name_ is used if it exists.