### PR TITLE
Fix: Do not self-update composer twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ cache:
 
 before_install:
   - if [[ "$WITH_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
-  - composer self-update
   - composer validate
   - composer config github-oauth.github.com $GITHUB_TOKEN
 


### PR DESCRIPTION
This PR

* [x] removes a second run of self-updating `composer`

💁‍♂️ It's updated on Travis itself, and it seems to work now!