### PR TITLE
Fix: Disable simplified_null_return fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -149,7 +149,7 @@ class Refinery29 extends Config
             'semicolon_after_instruction' => true,
             'short_scalar_cast' => true,
             'silenced_deprecation_error' => false,
-            'simplified_null_return' => true,
+            'simplified_null_return' => false,
             'single_blank_line_before_namespace' => true,
             'single_quote' => true,
             'space_after_semicolon' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -247,7 +247,7 @@ class Refinery29Test extends \PHPUnit_Framework_TestCase
             'semicolon_after_instruction' => true,
             'short_scalar_cast' => true,
             'silenced_deprecation_error' => false, // have not decided to use this one (yet)
-            'simplified_null_return' => true,
+            'simplified_null_return' => false,
             'single_blank_line_before_namespace' => true,
             'single_quote' => true,
             'space_after_semicolon' => true,


### PR DESCRIPTION
This PR

* [x] disables the `simplified_null_return` fixer

💁‍♂️ By popular request, when using PHP7, using this fixer is risky.