### PR TITLE
Fix: Mark production and test code as final

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -11,7 +11,7 @@ namespace Refinery29\CS\Config;
 
 use PhpCsFixer\Config;
 
-class Refinery29 extends Config
+final class Refinery29 extends Config
 {
     /**
      * @var string

--- a/test/ProjectCodeTest.php
+++ b/test/ProjectCodeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\CS\Config\Test;
+
+use Refinery29\Test\Util\TestHelper;
+
+final class ProjectCodeTest extends \PHPUnit_Framework_TestCase
+{
+    use TestHelper;
+
+    public function testProductionCodeIsAbstractOrFinal()
+    {
+        $this->assertClassesAreAbstractOrFinal(__DIR__ . '/../src');
+    }
+
+    public function testTestCodeIsAbstractOrFinal()
+    {
+        $this->assertClassesAreAbstractOrFinal(__DIR__);
+    }
+}

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -15,7 +15,7 @@ use PhpCsFixer\FixerFactory;
 use PhpCsFixer\RuleSet;
 use Refinery29\CS\Config\Refinery29;
 
-class Refinery29Test extends \PHPUnit_Framework_TestCase
+final class Refinery29Test extends \PHPUnit_Framework_TestCase
 {
     public function testImplementsInterface()
     {


### PR DESCRIPTION
This PR

* [x] asserts that production and test classes are either `abstract` or `final`
* [x] marks production and test classes as `final`
