### PR TITLE
Enhancement: Configure visibility_required fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -162,6 +162,11 @@ final class Refinery29 extends Config
             'trailing_comma_in_multiline_array' => true,
             'trim_array_spaces' => true,
             'unary_operator_spaces' => true,
+            'visibility_required' => [
+                'const',
+                'property',
+                'method',
+            ],
             'whitespace_after_comma_in_array' => true,
         ];
 

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -260,6 +260,11 @@ final class Refinery29Test extends \PHPUnit_Framework_TestCase
             'trailing_comma_in_multiline_array' => true,
             'trim_array_spaces' => true,
             'unary_operator_spaces' => true,
+            'visibility_required' => [
+                'const',
+                'property',
+                'method',
+            ],
             'whitespace_after_comma_in_array' => true,
         ];
     }


### PR DESCRIPTION
This PR

* [x] configures the `visibility_required` fixer to also require visibility on constants