### PR TITLE
Fix: Disable phpdoc_to_comment fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -134,7 +134,7 @@ final class Refinery29 extends Config
             'phpdoc_separation' => true,
             'phpdoc_single_line_var_spacing' => true,
             'phpdoc_summary' => true,
-            'phpdoc_to_comment' => true,
+            'phpdoc_to_comment' => false,
             'phpdoc_trim' => true,
             'phpdoc_types' => true,
             'phpdoc_var_without_name' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -232,7 +232,7 @@ final class Refinery29Test extends \PHPUnit_Framework_TestCase
             'phpdoc_separation' => true,
             'phpdoc_single_line_var_spacing' => true,
             'phpdoc_summary' => true,
-            'phpdoc_to_comment' => true,
+            'phpdoc_to_comment' => false,
             'phpdoc_trim' => true,
             'phpdoc_types' => true,
             'phpdoc_var_without_name' => true,


### PR DESCRIPTION
This PR

* [x] disable `phpdoc_to_comment`

Master is probably not the best branch to merge this since it requires php7. Anyway just to explain the reason behind this change.

If you want to add arbitrary comment somewhere in the code where you want to put `@see` annotation to give more context to the code, something like this
```php
/**
 * @see Controller::action()
 */
```
fixer will transform it to regular comment starting with `/*` which prevents PHPStorm from understanding that it really is a Docblock and you're not able to click on it to open the file.