### PR TITLE
Fix: Add note about why phpdoc_to_comment fixer is disabled

### DIFF
--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -232,7 +232,7 @@ final class Refinery29Test extends \PHPUnit_Framework_TestCase
             'phpdoc_separation' => true,
             'phpdoc_single_line_var_spacing' => true,
             'phpdoc_summary' => true,
-            'phpdoc_to_comment' => false,
+            'phpdoc_to_comment' => false, // it reduces usability of @see and @link annotations
             'phpdoc_trim' => true,
             'phpdoc_types' => true,
             'phpdoc_var_without_name' => true,


### PR DESCRIPTION
This PR

* [x] adds a note about why `phpdoc_to_comment` fixer has been disabled

Follows #160.