### PR TITLE
Fix: Update friendsofphp/php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": "^7.0",
-        "friendsofphp/php-cs-fixer": "^2.0.0"
+        "friendsofphp/php-cs-fixer": "^2.0.1"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "0.4.2",


### PR DESCRIPTION
This PR

* [x] updates `friendsofphp/php-cs-fixer`

Follows #168.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/compare/v2.0.0...v2.0.1.