### PR TITLE
Enhancement: Enable is_null fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -59,7 +59,9 @@ final class Refinery29 extends Config
             'header_comment' => false,
             'heredoc_to_nowdoc' => false,
             'include' => true,
-            'is_null' => false,
+            'is_null' => [
+                'use_yoda_style' => true,
+            ],
             'linebreak_after_opening_tag' => true,
             'lowercase_cast' => true,
             'mb_str_functions' => false,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -157,7 +157,9 @@ final class Refinery29Test extends \PHPUnit_Framework_TestCase
             'header_comment' => false, // not enabled by default
             'heredoc_to_nowdoc' => false, // have not decided to use this one (yet)
             'include' => true,
-            'is_null' => false, // have not decided to use this one (yet)
+            'is_null' => [
+                'use_yoda_style' => true,
+            ],
             'linebreak_after_opening_tag' => true,
             'lowercase_cast' => true,
             'mb_str_functions' => false, // have not decided to use this one (yet)


### PR DESCRIPTION
This PR

* [x] enables the `is_null` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

> `is_null [@Symfony:risky]`
>Replaces `is_null(parameter)` expression with `null === parameter`.
> Rule is: configurable, risky.