### PR TITLE
Enhancement: Enable native_function_invocation fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -66,7 +66,7 @@ final class Refinery29 extends Config
             'method_separation' => true,
             'modernize_types_casting' => true,
             'native_function_casing' => true,
-            'native_function_invocation' => false,
+            'native_function_invocation' => true,
             'new_with_braces' => true,
             'no_alias_functions' => true,
             'no_blank_lines_after_class_opening' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -164,7 +164,7 @@ final class Refinery29Test extends \PHPUnit_Framework_TestCase
             'method_separation' => true,
             'modernize_types_casting' => true,
             'native_function_casing' => true,
-            'native_function_invocation' => false, // have not decided to use this one (yet)
+            'native_function_invocation' => true,
             'new_with_braces' => true,
             'no_alias_functions' => true,
             'no_blank_lines_after_class_opening' => true,


### PR DESCRIPTION
This PR

* [x] enables the `native_function_invocation` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

>`native_function_invocation`
>Add leading `\` before function invocation of internal function to speed
>up resolving.
>Rule is: configurable, risky.