### PR TITLE
Enhancement: Enable phpdoc_no_useless_inheritdoc fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -133,7 +133,7 @@ final class Refinery29 extends Config
             ],
             'phpdoc_no_empty_return' => true,
             'phpdoc_no_package' => true,
-            'phpdoc_no_useless_inheritdoc' => false,
+            'phpdoc_no_useless_inheritdoc' => true,
             'phpdoc_return_self_reference' => false,
             'phpdoc_order' => true,
             'phpdoc_scalar' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -231,7 +231,7 @@ final class Refinery29Test extends \PHPUnit_Framework_TestCase
             ],
             'phpdoc_no_empty_return' => true,
             'phpdoc_no_package' => true,
-            'phpdoc_no_useless_inheritdoc' => false, // have not decided to use this one (yet)
+            'phpdoc_no_useless_inheritdoc' => true,
             'phpdoc_return_self_reference' => false, // have not decided to use this one (yet)
             'phpdoc_order' => true,
             'phpdoc_scalar' => true,


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_no_useless_inheritdoc` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

> `phpdoc_no_useless_inheritdoc [@Symfony]`
> Classy that does not inherit must not have inheritdoc tags.