### PR TITLE
Enhancement: Enable phpdoc_return_self_reference fixer

### DIFF
--- a/src/Refinery29.php
+++ b/src/Refinery29.php
@@ -134,7 +134,7 @@ final class Refinery29 extends Config
             'phpdoc_no_empty_return' => true,
             'phpdoc_no_package' => true,
             'phpdoc_no_useless_inheritdoc' => true,
-            'phpdoc_return_self_reference' => false,
+            'phpdoc_return_self_reference' => true,
             'phpdoc_order' => true,
             'phpdoc_scalar' => true,
             'phpdoc_separation' => true,

--- a/test/Refinery29Test.php
+++ b/test/Refinery29Test.php
@@ -232,7 +232,7 @@ final class Refinery29Test extends \PHPUnit_Framework_TestCase
             'phpdoc_no_empty_return' => true,
             'phpdoc_no_package' => true,
             'phpdoc_no_useless_inheritdoc' => true,
-            'phpdoc_return_self_reference' => false, // have not decided to use this one (yet)
+            'phpdoc_return_self_reference' => true,
             'phpdoc_order' => true,
             'phpdoc_scalar' => true,
             'phpdoc_separation' => true,


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_return_self_reference` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

> `phpdoc_return_self_reference [@Symfony]`
>The type of `@return` annotations of methods returning a reference to
>itself must the configured one.
>Rule is: configurable.