### PR TITLE
Fix: Update git pre-commit hook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ else
     echo ""
     echo "Please install php-cs-fixer, e.g.:"
     echo ""
-    echo "  composer require --dev friendsofphp/php-cs-fixer:2.0.0-RC"
+    echo "  composer require --dev friendsofphp/php-cs-fixer:^2.2.0
     echo ""
 fi
 


### PR DESCRIPTION
This PR

* [x] updates the git pre-commit hook example

💁‍♂️ It still references an old version of `friendsofphp/php-cs-fixer`.