### PR TITLE
Fix: Rename Refinery29 to Php71

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -7,7 +7,7 @@ For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 EOF;
 
-$config = new Refinery29\CS\Config\Refinery29($header);
+$config = new Refinery29\CS\Config\Php71($header);
 $config->getFinder()->in(__DIR__);
 
 $cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;

--- a/src/Php71.php
+++ b/src/Php71.php
@@ -13,7 +13,7 @@ namespace Refinery29\CS\Config;
 
 use PhpCsFixer\Config;
 
-final class Refinery29 extends Config
+final class Php71 extends Config
 {
     /**
      * @var string
@@ -25,7 +25,7 @@ final class Refinery29 extends Config
      */
     public function __construct($header = null)
     {
-        parent::__construct('refinery29');
+        parent::__construct('refinery29 (PHP 7.1)');
 
         $this->header = $header;
 

--- a/test/Php71Test.php
+++ b/test/Php71Test.php
@@ -15,29 +15,29 @@ use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerFactory;
 use PhpCsFixer\RuleSet;
-use Refinery29\CS\Config\Refinery29;
+use Refinery29\CS\Config\Php71;
 
-final class Refinery29Test extends \PHPUnit_Framework_TestCase
+final class Php71Test extends \PHPUnit_Framework_TestCase
 {
     public function testImplementsInterface()
     {
-        $config = new Refinery29();
+        $config = new Php71();
 
         $this->assertInstanceOf(ConfigInterface::class, $config);
     }
 
     public function testValues()
     {
-        $config = new Refinery29();
+        $config = new Php71();
 
-        $this->assertSame('refinery29', $config->getName());
+        $this->assertSame('refinery29 (PHP 7.1)', $config->getName());
         $this->assertTrue($config->getUsingCache());
         $this->assertTrue($config->getRiskyAllowed());
     }
 
     public function testHasRules()
     {
-        $config = new Refinery29();
+        $config = new Php71();
 
         $this->assertEquals($this->getRules(), $config->getRules());
     }
@@ -86,7 +86,7 @@ final class Refinery29Test extends \PHPUnit_Framework_TestCase
      */
     private function configuredFixers()
     {
-        $config = new Refinery29();
+        $config = new Php71();
 
         /**
          * RuleSet::create() removes disabled fixers, to let's just enable them to make sure they not removed.
@@ -102,7 +102,7 @@ final class Refinery29Test extends \PHPUnit_Framework_TestCase
 
     public function testDoesNotHaveHeaderCommentFixerByDefault()
     {
-        $config = new Refinery29();
+        $config = new Php71();
 
         $rules = $config->getRules();
 
@@ -114,7 +114,7 @@ final class Refinery29Test extends \PHPUnit_Framework_TestCase
     {
         $header = 'foo';
 
-        $config = new Refinery29($header);
+        $config = new Php71($header);
 
         $rules = $config->getRules();
 


### PR DESCRIPTION
This PR

* [x] renames `Refinery29` to `Php71`