### PR TITLE
Fix: Lower PHP version constraints

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -7,7 +7,7 @@ For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 EOF;
 
-$config = new Refinery29\CS\Config\Php71($header);
+$config = new Refinery29\CS\Config\Php56($header);
 $config->getFinder()->in(__DIR__);
 
 $cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,18 @@ env:
 
 matrix:
   include:
+    - php: 5.6
+      env: WITH_LOWEST=true
+    - php: 5.6
+      env: WITH_HIGHEST=true WITH_CS=true
+    - php: 7.0
+      env: WITH_LOWEST=true
+    - php: 7.0
+      env: WITH_HIGHEST=true
     - php: 7.1
       env: WITH_LOWEST=true
     - php: 7.1
-      env: WITH_HIGHEST=true WITH_CS=true WITH_COVERAGE=true
+      env: WITH_HIGHEST=true WITH_COVERAGE=true
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.1",
+        "php": "^5.6 || ^7.0",
         "friendsofphp/php-cs-fixer": "^2.2.0"
     },
     "require-dev": {

--- a/src/Php56.php
+++ b/src/Php56.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 
 /*
  * Copyright (c) 2016 Refinery29, Inc.

--- a/src/Php70.php
+++ b/src/Php70.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 
 /*
  * Copyright (c) 2016 Refinery29, Inc.

--- a/src/Php71.php
+++ b/src/Php71.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 
 /*
  * Copyright (c) 2016 Refinery29, Inc.

--- a/test/Php56Test.php
+++ b/test/Php56Test.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 
 /*
  * Copyright (c) 2016 Refinery29, Inc.

--- a/test/Php70Test.php
+++ b/test/Php70Test.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 
 /*
  * Copyright (c) 2016 Refinery29, Inc.

--- a/test/Php71Test.php
+++ b/test/Php71Test.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 
 /*
  * Copyright (c) 2016 Refinery29, Inc.

--- a/test/ProjectCodeTest.php
+++ b/test/ProjectCodeTest.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 
 /*
  * Copyright (c) 2016 Refinery29, Inc.


### PR DESCRIPTION
This PR

* [x] lowers the PHP version constraints
* [x] runs builds on PHP 5.6 and PHP 7.0
* [x] uses `Php56` for this project
* [x] removes `declare()` statements