### PR TITLE
Fix: Remove composer.lock in composer target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 it: cs test
 
 composer:
+	rm -rf composer.lock
 	composer self-update
 	composer validate
 	composer update


### PR DESCRIPTION
This PR

* [x] removes `composer.lock` in the `composer` target