### PR TITLE
Fix: Do not use yoda style conditions with is_null fixer

### DIFF
--- a/src/Php56.php
+++ b/src/Php56.php
@@ -64,9 +64,7 @@ final class Php56 extends Config
             'header_comment' => false,
             'heredoc_to_nowdoc' => false,
             'include' => true,
-            'is_null' => [
-                'use_yoda_style' => true,
-            ],
+            'is_null' => true,
             'linebreak_after_opening_tag' => true,
             'lowercase_cast' => true,
             'mb_str_functions' => false,


### PR DESCRIPTION
This PR

* [x] removes configuration for the `is_null` fixer to use yoda-style conditions

💁‍♂️ While yoda-style conditions are great, this is hard on legacy projects. We can still go back and re-enable it for all configurations.