### PR TITLE
Fix: Extract AbstractConfigTestCase

### DIFF
--- a/test/AbstractConfigTestCase.php
+++ b/test/AbstractConfigTestCase.php
@@ -1,0 +1,141 @@
+<?php
+
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\CS\Config\Test;
+
+use PhpCsFixer\ConfigInterface;
+use PhpCsFixer\Fixer;
+use PhpCsFixer\FixerFactory;
+use PhpCsFixer\RuleSet;
+use PHPUnit\Framework;
+
+abstract class AbstractConfigTestCase extends Framework\TestCase
+{
+    /**
+     * @param string $header
+     *
+     * @return ConfigInterface
+     */
+    abstract protected function createConfig($header = null);
+
+    /**
+     * @return string
+     */
+    abstract protected function name();
+
+    /**
+     * @return array
+     */
+    abstract protected function rules();
+
+    final public function testImplementsInterface()
+    {
+        $config = $this->createConfig();
+
+        $this->assertInstanceOf(ConfigInterface::class, $config);
+    }
+
+    final public function testDefaults()
+    {
+        $config = $this->createConfig();
+
+        $this->assertSame($this->name(), $config->getName());
+        $this->assertTrue($config->getUsingCache());
+        $this->assertTrue($config->getRiskyAllowed());
+    }
+
+    final public function testHasRules()
+    {
+        $config = $this->createConfig();
+
+        $this->assertEquals($this->rules(), $config->getRules());
+    }
+
+    final public function testAllConfiguredRulesAreBuiltIn()
+    {
+        $fixersNotBuiltIn = \array_diff(
+            $this->configuredFixers(),
+            $this->builtInFixers()
+        );
+
+        $this->assertEmpty($fixersNotBuiltIn, \sprintf(
+            'Failed to assert that fixers for the rules "%s" are built in',
+            \implode('", "', $fixersNotBuiltIn)
+        ));
+    }
+
+    final public function testAllBuiltInRulesAreConfigured()
+    {
+        $fixersWithoutConfiguration = \array_diff(
+            $this->builtInFixers(),
+            $this->configuredFixers()
+        );
+
+        $this->assertEmpty($fixersWithoutConfiguration, \sprintf(
+            'Failed to assert that built-in fixers for the rules "%s" are configured',
+            \implode('", "', $fixersWithoutConfiguration)
+        ));
+    }
+
+    public function testDoesNotHaveHeaderCommentFixerByDefault()
+    {
+        $rules = $this->createConfig()->getRules();
+
+        $this->assertArrayHasKey('header_comment', $rules);
+        $this->assertFalse($rules['header_comment']);
+    }
+
+    public function testHasHeaderCommentFixerIfProvided()
+    {
+        $header = 'foo';
+
+        $config = $this->createConfig($header);
+
+        $rules = $config->getRules();
+
+        $this->assertArrayHasKey('header_comment', $rules);
+
+        $expected = [
+            'header' => $header,
+        ];
+
+        $this->assertSame($expected, $rules['header_comment']);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function builtInFixers()
+    {
+        $fixerFactory = FixerFactory::create();
+        $fixerFactory->registerBuiltInFixers();
+
+        return \array_map(function (Fixer\FixerInterface $fixer) {
+            return $fixer->getName();
+        }, $fixerFactory->getFixers());
+    }
+
+    /**
+     * @return string[]
+     */
+    private function configuredFixers()
+    {
+        /**
+         * RuleSet::create() removes disabled fixers, to let's just enable them to make sure they not removed.
+         *
+         * @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2361
+         */
+        $rules = \array_map(function () {
+            return true;
+        }, $this->createConfig()->getRules());
+
+        return \array_keys(RuleSet::create($rules)->getRules());
+    }
+}

--- a/test/Php56Test.php
+++ b/test/Php56Test.php
@@ -10,126 +10,21 @@
 
 namespace Refinery29\CS\Config\Test;
 
-use PhpCsFixer\ConfigInterface;
-use PhpCsFixer\Fixer\FixerInterface;
-use PhpCsFixer\FixerFactory;
-use PhpCsFixer\RuleSet;
 use Refinery29\CS\Config\Php56;
 
-final class Php56Test extends \PHPUnit_Framework_TestCase
+final class Php56Test extends AbstractConfigTestCase
 {
-    public function testImplementsInterface()
+    protected function createConfig($header = null)
     {
-        $config = new Php56();
-
-        $this->assertInstanceOf(ConfigInterface::class, $config);
+        return new Php56($header);
     }
 
-    public function testValues()
+    protected function name()
     {
-        $config = new Php56();
-
-        $this->assertSame('refinery29 (PHP 5.6)', $config->getName());
-        $this->assertTrue($config->getUsingCache());
-        $this->assertTrue($config->getRiskyAllowed());
+        return 'refinery29 (PHP 5.6)';
     }
 
-    public function testHasRules()
-    {
-        $config = new Php56();
-
-        $this->assertEquals($this->getRules(), $config->getRules());
-    }
-
-    public function testAllConfiguredRulesAreBuiltIn()
-    {
-        $fixersNotBuiltIn = \array_diff(
-            $this->configuredFixers(),
-            $this->builtInFixers()
-        );
-
-        $this->assertEmpty($fixersNotBuiltIn, \sprintf(
-            'Failed to assert that fixers for the rules "%s" are built in',
-            \implode('", "', $fixersNotBuiltIn)
-        ));
-    }
-
-    public function testAllBuiltInRulesAreConfigured()
-    {
-        $fixersWithoutConfiguration = \array_diff(
-            $this->builtInFixers(),
-            $this->configuredFixers()
-        );
-
-        $this->assertEmpty($fixersWithoutConfiguration, \sprintf(
-            'Failed to assert that built-in fixers for the rules "%s" are configured',
-            \implode('", "', $fixersWithoutConfiguration)
-        ));
-    }
-
-    /**
-     * @return string[]
-     */
-    private function builtInFixers()
-    {
-        $fixerFactory = FixerFactory::create();
-        $fixerFactory->registerBuiltInFixers();
-
-        return \array_map(function (FixerInterface $fixer) {
-            return $fixer->getName();
-        }, $fixerFactory->getFixers());
-    }
-
-    /**
-     * @return string[]
-     */
-    private function configuredFixers()
-    {
-        $config = new Php56();
-
-        /**
-         * RuleSet::create() removes disabled fixers, to let's just enable them to make sure they not removed.
-         *
-         * @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2361
-         */
-        $rules = \array_map(function () {
-            return true;
-        }, $config->getRules());
-
-        return \array_keys(RuleSet::create($rules)->getRules());
-    }
-
-    public function testDoesNotHaveHeaderCommentFixerByDefault()
-    {
-        $config = new Php56();
-
-        $rules = $config->getRules();
-
-        $this->assertArrayHasKey('header_comment', $rules);
-        $this->assertFalse($rules['header_comment']);
-    }
-
-    public function testHasHeaderCommentFixerIfProvided()
-    {
-        $header = 'foo';
-
-        $config = new Php56($header);
-
-        $rules = $config->getRules();
-
-        $this->assertArrayHasKey('header_comment', $rules);
-
-        $expected = [
-            'header' => $header,
-        ];
-
-        $this->assertSame($expected, $rules['header_comment']);
-    }
-
-    /**
-     * @return array
-     */
-    private function getRules()
+    protected function rules()
     {
         return [
             '@PSR2' => true,

--- a/test/Php70Test.php
+++ b/test/Php70Test.php
@@ -10,126 +10,21 @@
 
 namespace Refinery29\CS\Config\Test;
 
-use PhpCsFixer\ConfigInterface;
-use PhpCsFixer\Fixer\FixerInterface;
-use PhpCsFixer\FixerFactory;
-use PhpCsFixer\RuleSet;
 use Refinery29\CS\Config\Php70;
 
-final class Php70Test extends \PHPUnit_Framework_TestCase
+final class Php70Test extends AbstractConfigTestCase
 {
-    public function testImplementsInterface()
+    protected function createConfig($header = null)
     {
-        $config = new Php70();
-
-        $this->assertInstanceOf(ConfigInterface::class, $config);
+        return new Php70($header);
     }
 
-    public function testValues()
+    protected function name()
     {
-        $config = new Php70();
-
-        $this->assertSame('refinery29 (PHP 7.0)', $config->getName());
-        $this->assertTrue($config->getUsingCache());
-        $this->assertTrue($config->getRiskyAllowed());
+        return 'refinery29 (PHP 7.0)';
     }
 
-    public function testHasRules()
-    {
-        $config = new Php70();
-
-        $this->assertEquals($this->getRules(), $config->getRules());
-    }
-
-    public function testAllConfiguredRulesAreBuiltIn()
-    {
-        $fixersNotBuiltIn = \array_diff(
-            $this->configuredFixers(),
-            $this->builtInFixers()
-        );
-
-        $this->assertEmpty($fixersNotBuiltIn, \sprintf(
-            'Failed to assert that fixers for the rules "%s" are built in',
-            \implode('", "', $fixersNotBuiltIn)
-        ));
-    }
-
-    public function testAllBuiltInRulesAreConfigured()
-    {
-        $fixersWithoutConfiguration = \array_diff(
-            $this->builtInFixers(),
-            $this->configuredFixers()
-        );
-
-        $this->assertEmpty($fixersWithoutConfiguration, \sprintf(
-            'Failed to assert that built-in fixers for the rules "%s" are configured',
-            \implode('", "', $fixersWithoutConfiguration)
-        ));
-    }
-
-    /**
-     * @return string[]
-     */
-    private function builtInFixers()
-    {
-        $fixerFactory = FixerFactory::create();
-        $fixerFactory->registerBuiltInFixers();
-
-        return \array_map(function (FixerInterface $fixer) {
-            return $fixer->getName();
-        }, $fixerFactory->getFixers());
-    }
-
-    /**
-     * @return string[]
-     */
-    private function configuredFixers()
-    {
-        $config = new Php70();
-
-        /**
-         * RuleSet::create() removes disabled fixers, to let's just enable them to make sure they not removed.
-         *
-         * @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2361
-         */
-        $rules = \array_map(function () {
-            return true;
-        }, $config->getRules());
-
-        return \array_keys(RuleSet::create($rules)->getRules());
-    }
-
-    public function testDoesNotHaveHeaderCommentFixerByDefault()
-    {
-        $config = new Php70();
-
-        $rules = $config->getRules();
-
-        $this->assertArrayHasKey('header_comment', $rules);
-        $this->assertFalse($rules['header_comment']);
-    }
-
-    public function testHasHeaderCommentFixerIfProvided()
-    {
-        $header = 'foo';
-
-        $config = new Php70($header);
-
-        $rules = $config->getRules();
-
-        $this->assertArrayHasKey('header_comment', $rules);
-
-        $expected = [
-            'header' => $header,
-        ];
-
-        $this->assertSame($expected, $rules['header_comment']);
-    }
-
-    /**
-     * @return array
-     */
-    private function getRules()
+    protected function rules()
     {
         return [
             '@PSR2' => true,

--- a/test/Php71Test.php
+++ b/test/Php71Test.php
@@ -10,126 +10,21 @@
 
 namespace Refinery29\CS\Config\Test;
 
-use PhpCsFixer\ConfigInterface;
-use PhpCsFixer\Fixer\FixerInterface;
-use PhpCsFixer\FixerFactory;
-use PhpCsFixer\RuleSet;
 use Refinery29\CS\Config\Php71;
 
-final class Php71Test extends \PHPUnit_Framework_TestCase
+final class Php71Test extends AbstractConfigTestCase
 {
-    public function testImplementsInterface()
+    protected function createConfig($header = null)
     {
-        $config = new Php71();
-
-        $this->assertInstanceOf(ConfigInterface::class, $config);
+        return new Php71($header);
     }
 
-    public function testValues()
+    protected function name()
     {
-        $config = new Php71();
-
-        $this->assertSame('refinery29 (PHP 7.1)', $config->getName());
-        $this->assertTrue($config->getUsingCache());
-        $this->assertTrue($config->getRiskyAllowed());
+        return 'refinery29 (PHP 7.1)';
     }
 
-    public function testHasRules()
-    {
-        $config = new Php71();
-
-        $this->assertEquals($this->getRules(), $config->getRules());
-    }
-
-    public function testAllConfiguredRulesAreBuiltIn()
-    {
-        $fixersNotBuiltIn = \array_diff(
-            $this->configuredFixers(),
-            $this->builtInFixers()
-        );
-
-        $this->assertEmpty($fixersNotBuiltIn, \sprintf(
-            'Failed to assert that fixers for the rules "%s" are built in',
-            \implode('", "', $fixersNotBuiltIn)
-        ));
-    }
-
-    public function testAllBuiltInRulesAreConfigured()
-    {
-        $fixersWithoutConfiguration = \array_diff(
-            $this->builtInFixers(),
-            $this->configuredFixers()
-        );
-
-        $this->assertEmpty($fixersWithoutConfiguration, \sprintf(
-            'Failed to assert that built-in fixers for the rules "%s" are configured',
-            \implode('", "', $fixersWithoutConfiguration)
-        ));
-    }
-
-    /**
-     * @return string[]
-     */
-    private function builtInFixers()
-    {
-        $fixerFactory = FixerFactory::create();
-        $fixerFactory->registerBuiltInFixers();
-
-        return \array_map(function (FixerInterface $fixer) {
-            return $fixer->getName();
-        }, $fixerFactory->getFixers());
-    }
-
-    /**
-     * @return string[]
-     */
-    private function configuredFixers()
-    {
-        $config = new Php71();
-
-        /**
-         * RuleSet::create() removes disabled fixers, to let's just enable them to make sure they not removed.
-         *
-         * @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2361
-         */
-        $rules = \array_map(function () {
-            return true;
-        }, $config->getRules());
-
-        return \array_keys(RuleSet::create($rules)->getRules());
-    }
-
-    public function testDoesNotHaveHeaderCommentFixerByDefault()
-    {
-        $config = new Php71();
-
-        $rules = $config->getRules();
-
-        $this->assertArrayHasKey('header_comment', $rules);
-        $this->assertFalse($rules['header_comment']);
-    }
-
-    public function testHasHeaderCommentFixerIfProvided()
-    {
-        $header = 'foo';
-
-        $config = new Php71($header);
-
-        $rules = $config->getRules();
-
-        $this->assertArrayHasKey('header_comment', $rules);
-
-        $expected = [
-            'header' => $header,
-        ];
-
-        $this->assertSame($expected, $rules['header_comment']);
-    }
-
-    /**
-     * @return array
-     */
-    private function getRules()
+    protected function rules()
     {
         return [
             '@PSR2' => true,


### PR DESCRIPTION
This PR

* [x] extracts an `AbstractConfigTestCase` 

Follows #181.
Follows #182.
Follows #183.