### PR TITLE
Enhancement: Enable doctrine_annotation_indentation fixer

### DIFF
--- a/src/Php56.php
+++ b/src/Php56.php
@@ -53,7 +53,7 @@ final class Php56 extends Config
             'declare_strict_types' => false,
             'dir_constant' => false,
             'doctrine_annotation_braces' => true,
-            'doctrine_annotation_indentation' => false,
+            'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => false,
             'ereg_to_preg' => false,
             'function_to_constant' => false,

--- a/src/Php70.php
+++ b/src/Php70.php
@@ -53,7 +53,7 @@ final class Php70 extends Config
             'declare_strict_types' => true,
             'dir_constant' => false,
             'doctrine_annotation_braces' => true,
-            'doctrine_annotation_indentation' => false,
+            'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => false,
             'ereg_to_preg' => false,
             'function_to_constant' => false,

--- a/src/Php71.php
+++ b/src/Php71.php
@@ -53,7 +53,7 @@ final class Php71 extends Config
             'declare_strict_types' => true,
             'dir_constant' => false,
             'doctrine_annotation_braces' => true,
-            'doctrine_annotation_indentation' => false,
+            'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => false,
             'ereg_to_preg' => false,
             'function_to_constant' => false,

--- a/test/Php56Test.php
+++ b/test/Php56Test.php
@@ -46,7 +46,7 @@ final class Php56Test extends AbstractConfigTestCase
             'declare_strict_types' => false, // relevant for PHP 7 and above only
             'dir_constant' => false, // risky
             'doctrine_annotation_braces' => true,
-            'doctrine_annotation_indentation' => false, // have not decided to use this one (yet)
+            'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => false, // have not decided to use this one (yet)
             'ereg_to_preg' => false, // risky
             'function_to_constant' => false, // have not decided to use this one (yet)

--- a/test/Php70Test.php
+++ b/test/Php70Test.php
@@ -46,7 +46,7 @@ final class Php70Test extends AbstractConfigTestCase
             'declare_strict_types' => true,
             'dir_constant' => false, // risky
             'doctrine_annotation_braces' => true,
-            'doctrine_annotation_indentation' => false, // have not decided to use this one (yet)
+            'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => false, // have not decided to use this one (yet)
             'ereg_to_preg' => false, // risky
             'function_to_constant' => false, // have not decided to use this one (yet)

--- a/test/Php71Test.php
+++ b/test/Php71Test.php
@@ -46,7 +46,7 @@ final class Php71Test extends AbstractConfigTestCase
             'declare_strict_types' => true,
             'dir_constant' => false, // risky
             'doctrine_annotation_braces' => true,
-            'doctrine_annotation_indentation' => false, // have not decided to use this one (yet)
+            'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => false, // have not decided to use this one (yet)
             'ereg_to_preg' => false, // risky
             'function_to_constant' => false, // have not decided to use this one (yet)


### PR DESCRIPTION
This PR

* [x] enables the `doctrine_annotation_indentation` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

>**doctrine_annotation_indentation**
>
>Doctrine annotations must be indented with four spaces.
