### PR TITLE
Enhancement: Enable doctrine_annotation_spaces fixer

### DIFF
--- a/src/Php56.php
+++ b/src/Php56.php
@@ -54,7 +54,7 @@ final class Php56 extends Config
             'dir_constant' => false,
             'doctrine_annotation_braces' => true,
             'doctrine_annotation_indentation' => true,
-            'doctrine_annotation_spaces' => false,
+            'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => false,
             'function_to_constant' => false,
             'function_typehint_space' => true,

--- a/src/Php70.php
+++ b/src/Php70.php
@@ -54,7 +54,7 @@ final class Php70 extends Config
             'dir_constant' => false,
             'doctrine_annotation_braces' => true,
             'doctrine_annotation_indentation' => true,
-            'doctrine_annotation_spaces' => false,
+            'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => false,
             'function_to_constant' => false,
             'function_typehint_space' => true,

--- a/src/Php71.php
+++ b/src/Php71.php
@@ -54,7 +54,7 @@ final class Php71 extends Config
             'dir_constant' => false,
             'doctrine_annotation_braces' => true,
             'doctrine_annotation_indentation' => true,
-            'doctrine_annotation_spaces' => false,
+            'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => false,
             'function_to_constant' => false,
             'function_typehint_space' => true,

--- a/test/Php56Test.php
+++ b/test/Php56Test.php
@@ -47,7 +47,7 @@ final class Php56Test extends AbstractConfigTestCase
             'dir_constant' => false, // risky
             'doctrine_annotation_braces' => true,
             'doctrine_annotation_indentation' => true,
-            'doctrine_annotation_spaces' => false, // have not decided to use this one (yet)
+            'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => false, // risky
             'function_to_constant' => false, // have not decided to use this one (yet)
             'function_typehint_space' => true,

--- a/test/Php70Test.php
+++ b/test/Php70Test.php
@@ -47,7 +47,7 @@ final class Php70Test extends AbstractConfigTestCase
             'dir_constant' => false, // risky
             'doctrine_annotation_braces' => true,
             'doctrine_annotation_indentation' => true,
-            'doctrine_annotation_spaces' => false, // have not decided to use this one (yet)
+            'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => false, // risky
             'function_to_constant' => false, // have not decided to use this one (yet)
             'function_typehint_space' => true,

--- a/test/Php71Test.php
+++ b/test/Php71Test.php
@@ -47,7 +47,7 @@ final class Php71Test extends AbstractConfigTestCase
             'dir_constant' => false, // risky
             'doctrine_annotation_braces' => true,
             'doctrine_annotation_indentation' => true,
-            'doctrine_annotation_spaces' => false, // have not decided to use this one (yet)
+            'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => false, // risky
             'function_to_constant' => false, // have not decided to use this one (yet)
             'function_typehint_space' => true,


### PR DESCRIPTION
This PR

* [x] enables the `doctrine_annotation_spaces` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

>**doctrine_annotation_spaces**
>
>Fixes spaces in Doctrine annotations.
