### PR TITLE
Enhancement: Enable function_to_constant fixer

### DIFF
--- a/src/Php56.php
+++ b/src/Php56.php
@@ -56,7 +56,7 @@ final class Php56 extends Config
             'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => false,
-            'function_to_constant' => false,
+            'function_to_constant' => true,
             'function_typehint_space' => true,
             'general_phpdoc_annotation_remove' => false,
             'hash_to_slash_comment' => true,

--- a/src/Php70.php
+++ b/src/Php70.php
@@ -56,7 +56,7 @@ final class Php70 extends Config
             'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => false,
-            'function_to_constant' => false,
+            'function_to_constant' => true,
             'function_typehint_space' => true,
             'general_phpdoc_annotation_remove' => false,
             'hash_to_slash_comment' => true,

--- a/src/Php71.php
+++ b/src/Php71.php
@@ -56,7 +56,7 @@ final class Php71 extends Config
             'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => false,
-            'function_to_constant' => false,
+            'function_to_constant' => true,
             'function_typehint_space' => true,
             'general_phpdoc_annotation_remove' => false,
             'hash_to_slash_comment' => true,

--- a/test/Php56Test.php
+++ b/test/Php56Test.php
@@ -49,7 +49,7 @@ final class Php56Test extends AbstractConfigTestCase
             'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => false, // risky
-            'function_to_constant' => false, // have not decided to use this one (yet)
+            'function_to_constant' => true,
             'function_typehint_space' => true,
             'general_phpdoc_annotation_remove' => false, // have not decided to use this one (yet)
             'hash_to_slash_comment' => true,

--- a/test/Php70Test.php
+++ b/test/Php70Test.php
@@ -49,7 +49,7 @@ final class Php70Test extends AbstractConfigTestCase
             'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => false, // risky
-            'function_to_constant' => false, // have not decided to use this one (yet)
+            'function_to_constant' => true,
             'function_typehint_space' => true,
             'general_phpdoc_annotation_remove' => false, // have not decided to use this one (yet)
             'hash_to_slash_comment' => true,

--- a/test/Php71Test.php
+++ b/test/Php71Test.php
@@ -49,7 +49,7 @@ final class Php71Test extends AbstractConfigTestCase
             'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => false, // risky
-            'function_to_constant' => false, // have not decided to use this one (yet)
+            'function_to_constant' => true,
             'function_typehint_space' => true,
             'general_phpdoc_annotation_remove' => false, // have not decided to use this one (yet)
             'hash_to_slash_comment' => true,


### PR DESCRIPTION
This PR

* [x] enables the `function_to_constant` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

>**function_to_constant** [`@Symfony:risky`]
>
>Replace core functions calls returning constants with the constants.
>
>*Risky rule: risky when any of the configured functions to replace are overridden.*