### PR TITLE
Enhancement: Enable magic_constant_casing fixer

### DIFF
--- a/src/Php56.php
+++ b/src/Php56.php
@@ -67,7 +67,7 @@ final class Php56 extends Config
             'linebreak_after_opening_tag' => true,
             'lowercase_cast' => true,
             'mb_str_functions' => false,
-            'magic_constant_casing' => false,
+            'magic_constant_casing' => true,
             'method_separation' => true,
             'modernize_types_casting' => true,
             'native_function_casing' => true,

--- a/src/Php70.php
+++ b/src/Php70.php
@@ -67,7 +67,7 @@ final class Php70 extends Config
             'linebreak_after_opening_tag' => true,
             'lowercase_cast' => true,
             'mb_str_functions' => false,
-            'magic_constant_casing' => false,
+            'magic_constant_casing' => true,
             'method_separation' => true,
             'modernize_types_casting' => true,
             'native_function_casing' => true,

--- a/src/Php71.php
+++ b/src/Php71.php
@@ -67,7 +67,7 @@ final class Php71 extends Config
             'linebreak_after_opening_tag' => true,
             'lowercase_cast' => true,
             'mb_str_functions' => false,
-            'magic_constant_casing' => false,
+            'magic_constant_casing' => true,
             'method_separation' => true,
             'modernize_types_casting' => true,
             'native_function_casing' => true,

--- a/test/Php56Test.php
+++ b/test/Php56Test.php
@@ -60,7 +60,7 @@ final class Php56Test extends AbstractConfigTestCase
             'linebreak_after_opening_tag' => true,
             'lowercase_cast' => true,
             'mb_str_functions' => false, // have not decided to use this one (yet)
-            'magic_constant_casing' => false, // have not decided to use this one (yet)
+            'magic_constant_casing' => true,
             'method_separation' => true,
             'modernize_types_casting' => true,
             'native_function_casing' => true,

--- a/test/Php70Test.php
+++ b/test/Php70Test.php
@@ -60,7 +60,7 @@ final class Php70Test extends AbstractConfigTestCase
             'linebreak_after_opening_tag' => true,
             'lowercase_cast' => true,
             'mb_str_functions' => false, // have not decided to use this one (yet)
-            'magic_constant_casing' => false, // have not decided to use this one (yet)
+            'magic_constant_casing' => true,
             'method_separation' => true,
             'modernize_types_casting' => true,
             'native_function_casing' => true,

--- a/test/Php71Test.php
+++ b/test/Php71Test.php
@@ -60,7 +60,7 @@ final class Php71Test extends AbstractConfigTestCase
             'linebreak_after_opening_tag' => true,
             'lowercase_cast' => true,
             'mb_str_functions' => false, // have not decided to use this one (yet)
-            'magic_constant_casing' => false, // have not decided to use this one (yet)
+            'magic_constant_casing' => true,
             'method_separation' => true,
             'modernize_types_casting' => true,
             'native_function_casing' => true,


### PR DESCRIPTION
This PR

* [x] enables the `magic_constant_casing` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

>magic_constant_casing [`@Symfony`]
>
>Magic constants should be referred to using the correct casing.