### PR TITLE
Enhancement: Enable non_printable_character fixer

### DIFF
--- a/src/Php56.php
+++ b/src/Php56.php
@@ -113,7 +113,7 @@ final class Php56 extends Config
             'no_useless_return' => true,
             'no_whitespace_before_comma_in_array' => true,
             'no_whitespace_in_blank_line' => true,
-            'non_printable_character' => false,
+            'non_printable_character' => true,
             'normalize_index_brace' => true,
             'not_operator_with_space' => false,
             'not_operator_with_successor_space' => false,

--- a/src/Php70.php
+++ b/src/Php70.php
@@ -113,7 +113,7 @@ final class Php70 extends Config
             'no_useless_return' => true,
             'no_whitespace_before_comma_in_array' => true,
             'no_whitespace_in_blank_line' => true,
-            'non_printable_character' => false,
+            'non_printable_character' => true,
             'normalize_index_brace' => true,
             'not_operator_with_space' => false,
             'not_operator_with_successor_space' => false,

--- a/src/Php71.php
+++ b/src/Php71.php
@@ -113,7 +113,7 @@ final class Php71 extends Config
             'no_useless_return' => true,
             'no_whitespace_before_comma_in_array' => true,
             'no_whitespace_in_blank_line' => true,
-            'non_printable_character' => false,
+            'non_printable_character' => true,
             'normalize_index_brace' => true,
             'not_operator_with_space' => false,
             'not_operator_with_successor_space' => false,

--- a/test/Php56Test.php
+++ b/test/Php56Test.php
@@ -106,7 +106,7 @@ final class Php56Test extends AbstractConfigTestCase
             'no_useless_return' => true,
             'no_whitespace_before_comma_in_array' => true,
             'no_whitespace_in_blank_line' => true,
-            'non_printable_character' => false, // have not decided to use this one (yet)
+            'non_printable_character' => true,
             'normalize_index_brace' => true,
             'not_operator_with_space' => false, // have decided not to use it
             'not_operator_with_successor_space' => false, // have decided not to use it

--- a/test/Php70Test.php
+++ b/test/Php70Test.php
@@ -106,7 +106,7 @@ final class Php70Test extends AbstractConfigTestCase
             'no_useless_return' => true,
             'no_whitespace_before_comma_in_array' => true,
             'no_whitespace_in_blank_line' => true,
-            'non_printable_character' => false, // have not decided to use this one (yet)
+            'non_printable_character' => true,
             'normalize_index_brace' => true,
             'not_operator_with_space' => false, // have decided not to use it
             'not_operator_with_successor_space' => false, // have decided not to use it

--- a/test/Php71Test.php
+++ b/test/Php71Test.php
@@ -106,7 +106,7 @@ final class Php71Test extends AbstractConfigTestCase
             'no_useless_return' => true,
             'no_whitespace_before_comma_in_array' => true,
             'no_whitespace_in_blank_line' => true,
-            'non_printable_character' => false, // have not decided to use this one (yet)
+            'non_printable_character' => true,
             'normalize_index_brace' => true,
             'not_operator_with_space' => false, // have decided not to use it
             'not_operator_with_successor_space' => false, // have decided not to use it


### PR DESCRIPTION
This PR

* [x] enables the `non_printable_character ` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

>**non_printable_character** [`@Symfony:risky`]
>
>Remove Zero-width space (ZWSP), Non-breaking space (NBSP) and other invisible unicode symbols.
>
>Risky rule: risky when strings contain intended invisible characters.