### PR TITLE
Enhancement: Enable list_syntax fixer

### DIFF
--- a/src/Php71.php
+++ b/src/Php71.php
@@ -65,7 +65,9 @@ final class Php71 extends Config
             'include' => true,
             'is_null' => true,
             'linebreak_after_opening_tag' => true,
-            'list_syntax' => false,
+            'list_syntax' => [
+                'syntax' => 'short',
+            ],
             'lowercase_cast' => true,
             'mb_str_functions' => false,
             'magic_constant_casing' => true,

--- a/test/Php71Test.php
+++ b/test/Php71Test.php
@@ -58,7 +58,9 @@ final class Php71Test extends AbstractConfigTestCase
             'include' => true,
             'is_null' => true,
             'linebreak_after_opening_tag' => true,
-            'list_syntax' => false, // have not decided to use this one (yet)
+            'list_syntax' => [
+                'syntax' => 'short',
+            ],
             'lowercase_cast' => true,
             'mb_str_functions' => false, // have not decided to use this one (yet)
             'magic_constant_casing' => true,


### PR DESCRIPTION
This PR

* [x] enables the `list_syntax` fixer

Follows #200.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

>list_syntax
>
>List (`array` destructuring) assignment should be declared using the configured syntax. Requires PHP >>= 7.1.
>
>Configuration options:
>
>`syntax` (`'long'`, `'short'`): whether to use the `long` or `short` `list` syntax; defaults to `'long'`
