### PR TITLE
Fix: Use relative path for phpunit.xsd instead of absolute, remote path

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.7/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="vendor/autoload.php"
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"


### PR DESCRIPTION
This PR

* [x] uses a relative path to `phpunit.xsd` instead of an absolute, remote path

💁‍♂️ This way it will always link to the appropriate schema, regardless of which version is installed, and doesn't need any updates. For reference, also see https://github.com/sebastianbergmann/phpunit/blob/master/phpunit.xsd.