### PR TITLE
Use appropriate rule set in tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ before_install:
   - source .travis/xdebug.sh
   - xdebug-disable
   - composer validate
-  - composer config github-oauth.github.com $GITHUB_TOKEN
+  - composer config -g github-oauth.github.com $GH_TOKEN
+  - unset GH_TOKEN
 
 install:
   - if [[ "$WITH_LOWEST" == "true" ]]; then composer update --prefer-lowest; else composer install; fi

--- a/test/AbstractConfigTestCase.php
+++ b/test/AbstractConfigTestCase.php
@@ -74,7 +74,7 @@ abstract class AbstractConfigTestCase extends Framework\TestCase
     final public function testAllBuiltInRulesAreConfigured()
     {
         $fixersWithoutConfiguration = \array_diff(
-            $this->builtInFixers(),
+            $this->builtInFixers(true),
             $this->configuredFixers()
         );
 
@@ -110,12 +110,19 @@ abstract class AbstractConfigTestCase extends Framework\TestCase
     }
 
     /**
+     * @param bool $useRuleSet
      * @return string[]
      */
-    private function builtInFixers()
+    private function builtInFixers($useRuleSet = false)
     {
+        $rules = $this->createConfig()->getRules();
+
         $fixerFactory = FixerFactory::create();
         $fixerFactory->registerBuiltInFixers();
+
+        if ($useRuleSet === true) {
+            $fixerFactory->useRuleSet(new RuleSet($rules));
+        }
 
         return \array_map(function (Fixer\FixerInterface $fixer) {
             return $fixer->getName();


### PR DESCRIPTION
When checking built in rules against configured rules, use the rule set
current under test so that built in rules which aren't relevant for the current
rule set don't fail the test.

This PR

* [x] Fixes tests for versions of php-cs-fixer later than 2.3.2

Locally tests were failing for me on versions of php-cs-fixer later than 2.3.2. This should fix it.
